### PR TITLE
Organize package and add pyproject with CLI entry point

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -1,30 +1,16 @@
 #!/usr/bin/env python3
-"""Minimal command line interface for barrow."""
+"""Command line interface for barrow."""
+
+from __future__ import annotations
 
 import argparse
-import sys
-import pyarrow.csv as csv
-import pyarrow.parquet as pq
-import pyarrow as pa
 
-
-def read_table(path: str | None) -> pa.Table:
-    """Read a CSV file from the given path or STDIN if path is None."""
-    if path:
-        return csv.read_csv(path)
-    data = sys.stdin.buffer.read()
-    return csv.read_csv(pa.BufferReader(data))
-
-
-def write_table(table: pa.Table, path: str | None) -> None:
-    """Write the table to the given path as parquet or to STDOUT as CSV."""
-    if path:
-        pq.write_table(table, path)
-    else:
-        csv.write_csv(table, sys.stdout)
+from .io import read_table, write_table
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``barrow`` command line tool."""
+
     parser = argparse.ArgumentParser(description="barrow: simple data tool")
     parser.add_argument("--input", "-i", help="Input CSV file. Reads STDIN if omitted.")
     parser.add_argument("--output", "-o", help="Output parquet file. Writes CSV to STDOUT if omitted.")
@@ -35,5 +21,6 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(main())
+

--- a/barrow/expr/__init__.py
+++ b/barrow/expr/__init__.py
@@ -1,0 +1,7 @@
+"""Expression system for :mod:`barrow`.
+
+The expression module will provide a small domain specific language to
+describe column transformations.  It currently acts as a placeholder."""
+
+__all__: list[str] = []
+

--- a/barrow/io/__init__.py
+++ b/barrow/io/__init__.py
@@ -1,0 +1,40 @@
+"""I/O utilities for barrow.
+
+This module contains helper functions to read and write tabular data
+using Apache Arrow. It provides a small abstraction over the CSV and
+Parquet readers so the rest of the project can operate on in-memory
+Arrow tables.
+"""
+
+from __future__ import annotations
+
+import sys
+import pyarrow as pa
+import pyarrow.csv as csv
+import pyarrow.parquet as pq
+
+
+def read_table(path: str | None) -> pa.Table:
+    """Read a CSV file from ``path`` or from ``STDIN`` when ``path`` is ``None``."""
+
+    if path:
+        return csv.read_csv(path)
+    data = sys.stdin.buffer.read()
+    return csv.read_csv(pa.BufferReader(data))
+
+
+def write_table(table: pa.Table, path: str | None) -> None:
+    """Write ``table`` to ``path`` as Parquet or emit CSV to ``STDOUT``.
+
+    When ``path`` is ``None`` the table is written as CSV to ``STDOUT``.
+    Otherwise a Parquet file is created at the given path.
+    """
+
+    if path:
+        pq.write_table(table, path)
+    else:
+        csv.write_csv(table, sys.stdout.buffer)
+
+
+__all__ = ["read_table", "write_table"]
+

--- a/barrow/operations/__init__.py
+++ b/barrow/operations/__init__.py
@@ -1,0 +1,7 @@
+"""Data operations for :mod:`barrow`.
+
+This package will host transformation primitives such as filter,
+select and aggregation functions in the future."""
+
+__all__: list[str] = []
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "barrow"
+version = "0.1.0"
+description = "A Bash tool for data manipulation using tabular formats, based on Apache Arrow."
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [{name = "Barrow Developers"}]
+dependencies = [
+    "pyarrow",
+]
+
+[project.scripts]
+barrow = "barrow.cli:main"
+

--- a/tests/expr/__init__.py
+++ b/tests/expr/__init__.py
@@ -1,0 +1,2 @@
+"""Tests for :mod:`barrow.expr`."""
+

--- a/tests/expr/test_placeholder.py
+++ b/tests/expr/test_placeholder.py
@@ -1,0 +1,3 @@
+def test_expr_placeholder():
+    assert True
+

--- a/tests/io/__init__.py
+++ b/tests/io/__init__.py
@@ -1,0 +1,2 @@
+"""Tests for :mod:`barrow.io`."""
+

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow as pa
+
+from barrow.io import read_table, write_table
+
+
+def test_read_table_from_path(tmp_path: Path) -> None:
+    data = "a,b\n1,2\n"
+    csv_path = tmp_path / "input.csv"
+    csv_path.write_text(data)
+
+    table = read_table(str(csv_path))
+    assert table.to_pylist() == [{"a": 1, "b": 2}]
+
+
+def test_write_table_to_stdout(capsys) -> None:
+    table = pa.table({"a": [1]})
+    write_table(table, None)
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out[0] == '"a"'
+    assert out[1] == "1"
+
+
+def test_write_table_to_parquet(tmp_path: Path) -> None:
+    table = pa.table({"a": [1]})
+    pq_path = tmp_path / "output.parquet"
+
+    write_table(table, str(pq_path))
+    assert pq_path.exists()
+

--- a/tests/operations/__init__.py
+++ b/tests/operations/__init__.py
@@ -1,0 +1,2 @@
+"""Tests for :mod:`barrow.operations`."""
+

--- a/tests/operations/test_placeholder.py
+++ b/tests/operations/test_placeholder.py
@@ -1,0 +1,3 @@
+def test_operations_placeholder():
+    assert True
+

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert True


### PR DESCRIPTION
## Summary
- create initial pyproject with pyarrow dependency and barrow console script
- move I/O helpers into barrow.io and provide placeholder operations/expr packages
- expand tests for I/O reading and writing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcaf085250832ab7e329a69a761922