### PR TITLE
feat: add format-aware IO utilities

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -16,8 +16,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", "-o", help="Output parquet file. Writes CSV to STDOUT if omitted.")
     args = parser.parse_args(argv)
 
-    table = read_table(args.input)
-    write_table(table, args.output)
+    table = read_table(args.input, "csv")
+    write_table(table, args.output, "parquet")
     return 0
 
 

--- a/barrow/io/__init__.py
+++ b/barrow/io/__init__.py
@@ -1,40 +1,10 @@
 """I/O utilities for barrow.
 
-This module contains helper functions to read and write tabular data
-using Apache Arrow. It provides a small abstraction over the CSV and
-Parquet readers so the rest of the project can operate on in-memory
-Arrow tables.
+This package provides helper functions to read and write tabular data
+using Apache Arrow.
 """
 
-from __future__ import annotations
-
-import sys
-import pyarrow as pa
-import pyarrow.csv as csv
-import pyarrow.parquet as pq
-
-
-def read_table(path: str | None) -> pa.Table:
-    """Read a CSV file from ``path`` or from ``STDIN`` when ``path`` is ``None``."""
-
-    if path:
-        return csv.read_csv(path)
-    data = sys.stdin.buffer.read()
-    return csv.read_csv(pa.BufferReader(data))
-
-
-def write_table(table: pa.Table, path: str | None) -> None:
-    """Write ``table`` to ``path`` as Parquet or emit CSV to ``STDOUT``.
-
-    When ``path`` is ``None`` the table is written as CSV to ``STDOUT``.
-    Otherwise a Parquet file is created at the given path.
-    """
-
-    if path:
-        pq.write_table(table, path)
-    else:
-        csv.write_csv(table, sys.stdout.buffer)
-
+from .reader import read_table
+from .writer import write_table
 
 __all__ = ["read_table", "write_table"]
-

--- a/barrow/io/reader.py
+++ b/barrow/io/reader.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import sys
+import pyarrow as pa
+import pyarrow.csv as csv
+import pyarrow.parquet as pq
+
+
+def read_table(path: str | None, format: str) -> pa.Table:
+    """Read a table from ``path`` or ``STDIN``.
+
+    Parameters
+    ----------
+    path:
+        Path to the input file. When ``None`` the data is read from ``STDIN``.
+    format:
+        The file format. Supported values are ``"csv"`` and ``"parquet"``.
+    """
+    fmt = format.lower()
+    if fmt == "csv":
+        if path:
+            return csv.read_csv(path)
+        data = sys.stdin.buffer.read()
+        return csv.read_csv(pa.BufferReader(data))
+    if fmt == "parquet":
+        if path:
+            return pq.read_table(path)
+        data = sys.stdin.buffer.read()
+        return pq.read_table(pa.BufferReader(data))
+    raise ValueError(f"Unsupported format: {format}")

--- a/barrow/io/writer.py
+++ b/barrow/io/writer.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+import pyarrow as pa
+import pyarrow.csv as csv
+import pyarrow.parquet as pq
+
+
+def write_table(table: pa.Table, path: str | None, format: str) -> None:
+    """Write ``table`` to ``path`` or ``STDOUT``.
+
+    Parameters
+    ----------
+    table:
+        Table to serialise.
+    path:
+        Destination path. When ``None`` the table is written to ``STDOUT``.
+    format:
+        The file format. Supported values are ``"csv"`` and ``"parquet"``.
+    """
+    fmt = format.lower()
+    if fmt == "csv":
+        if path:
+            csv.write_csv(table, path)
+        else:
+            csv.write_csv(table, sys.stdout.buffer)
+        return
+    if fmt == "parquet":
+        if path:
+            pq.write_table(table, path)
+        else:
+            pq.write_table(table, sys.stdout.buffer)
+        return
+    raise ValueError(f"Unsupported format: {format}")

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+import io
+import sys
 
 import pyarrow as pa
 
@@ -12,13 +14,22 @@ def test_read_table_from_path(tmp_path: Path) -> None:
     csv_path = tmp_path / "input.csv"
     csv_path.write_text(data)
 
-    table = read_table(str(csv_path))
+    table = read_table(str(csv_path), "csv")
+    assert table.to_pylist() == [{"a": 1, "b": 2}]
+
+
+def test_read_table_from_stdin(monkeypatch) -> None:
+    data = b"a,b\n1,2\n"
+    stdin = io.BytesIO(data)
+    monkeypatch.setattr(sys, "stdin", io.TextIOWrapper(stdin, encoding="utf-8"))
+
+    table = read_table(None, "csv")
     assert table.to_pylist() == [{"a": 1, "b": 2}]
 
 
 def test_write_table_to_stdout(capsys) -> None:
     table = pa.table({"a": [1]})
-    write_table(table, None)
+    write_table(table, None, "csv")
     out = capsys.readouterr().out.strip().splitlines()
     assert out[0] == '"a"'
     assert out[1] == "1"
@@ -28,6 +39,6 @@ def test_write_table_to_parquet(tmp_path: Path) -> None:
     table = pa.table({"a": [1]})
     pq_path = tmp_path / "output.parquet"
 
-    write_table(table, str(pq_path))
+    write_table(table, str(pq_path), "parquet")
     assert pq_path.exists()
 


### PR DESCRIPTION
## Summary
- support CSV and Parquet formats for reading and writing with format argument
- add reader and writer modules with stdin/stdout support
- update CLI and tests to use new APIs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcafff18bc832a91eacfa5b885b716