### PR TITLE
Implement core table transformation operations

### DIFF
--- a/barrow/operations/__init__.py
+++ b/barrow/operations/__init__.py
@@ -1,7 +1,15 @@
 """Data operations for :mod:`barrow`.
 
-This package will host transformation primitives such as filter,
-select and aggregation functions in the future."""
+This package contains transformation primitives used by the command line
+interface, such as selecting columns, filtering rows and performing
+aggregations.
+"""
 
-__all__: list[str] = []
+from .select import select
+from .filter import filter
+from .mutate import mutate
+from .groupby import groupby
+from .summary import summary
+
+__all__ = ["select", "filter", "mutate", "groupby", "summary"]
 

--- a/barrow/operations/filter.py
+++ b/barrow/operations/filter.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Row filtering operation using Python expressions."""
+
+import numpy as np
+import pyarrow as pa
+
+
+def filter(table: pa.Table, expression: str) -> pa.Table:
+    """Filter ``table`` by evaluating ``expression``.
+
+    The expression is evaluated with a namespace containing the table's
+    columns as :class:`numpy.ndarray` objects and all functions from
+    :mod:`numpy`.
+    """
+    env: dict[str, object] = {
+        name: table[name].to_numpy(zero_copy_only=False) for name in table.column_names
+    }
+    env.update({name: getattr(np, name) for name in dir(np) if not name.startswith("_")})
+    mask = eval(expression, {"__builtins__": {}}, env)
+    return table.filter(pa.array(mask))
+
+
+__all__ = ["filter"]

--- a/barrow/operations/groupby.py
+++ b/barrow/operations/groupby.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Grouping utilities."""
+
+import pyarrow as pa
+
+
+def groupby(table: pa.Table, keys: str | list[str], *, use_threads: bool = True) -> pa.TableGroupBy:
+    """Group ``table`` by ``keys``.
+
+    This is a thin wrapper over :meth:`pyarrow.Table.group_by` that exposes the
+    ``use_threads`` parameter for deterministic testing.
+    """
+    return table.group_by(keys, use_threads=use_threads)
+
+
+__all__ = ["groupby"]

--- a/barrow/operations/mutate.py
+++ b/barrow/operations/mutate.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Column creation and transformation operation."""
+
+import numpy as np
+import pyarrow as pa
+
+
+def mutate(table: pa.Table, **expressions: str) -> pa.Table:
+    """Return a new table with columns created or replaced.
+
+    Each keyword argument represents the name of the resulting column and its
+    value is a Python expression evaluated using the existing columns and
+    functions from :mod:`numpy`.
+    """
+    env: dict[str, object] = {
+        name: table[name].to_numpy(zero_copy_only=False) for name in table.column_names
+    }
+    env.update({name: getattr(np, name) for name in dir(np) if not name.startswith("_")})
+    out = table
+    for name, expr in expressions.items():
+        value = eval(expr, {"__builtins__": {}}, env)
+        arr = pa.array(value)
+        if name in out.column_names:
+            idx = out.column_names.index(name)
+            out = out.set_column(idx, name, arr)
+        else:
+            out = out.append_column(name, arr)
+        env[name] = value
+    return out
+
+
+__all__ = ["mutate"]

--- a/barrow/operations/select.py
+++ b/barrow/operations/select.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""Column selection operation."""
+
+import pyarrow as pa
+
+
+def select(table: pa.Table, columns: str | list[str] | tuple[str, ...]) -> pa.Table:
+    """Return a table with only *columns*.
+
+    Parameters
+    ----------
+    table:
+        Input table.
+    columns:
+        Column name or names to keep.
+    """
+    if isinstance(columns, (str, bytes)):
+        cols = [columns]
+    else:
+        cols = list(columns)
+    return table.select(cols)
+
+
+__all__ = ["select"]

--- a/barrow/operations/summary.py
+++ b/barrow/operations/summary.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Aggregation helpers for grouped tables."""
+
+from collections.abc import Mapping
+
+import pyarrow as pa
+
+
+def summary(grouped: pa.TableGroupBy, aggregations: Mapping[str, str] | None = None, **kwargs: str) -> pa.Table:
+    """Aggregate ``grouped`` according to ``aggregations``.
+
+    Aggregations can be passed either as a mapping or as keyword arguments where
+    keys are column names and values are the aggregation function (e.g. ``"sum"``).
+    """
+    if aggregations is None:
+        aggregations = {}
+    aggregations = {**aggregations, **kwargs}
+    pairs = list(aggregations.items())
+    return grouped.aggregate(pairs)
+
+
+__all__ = ["summary"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = {text = "MIT"}
 authors = [{name = "Barrow Developers"}]
 dependencies = [
     "pyarrow",
+    "numpy",
 ]
 
 [project.scripts]

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -1,0 +1,41 @@
+import pyarrow as pa
+
+from barrow.operations import (
+    select,
+    filter as filter_rows,
+    mutate,
+    groupby,
+    summary,
+)
+
+
+def make_table():
+    return pa.table({"a": [1, 2, 3], "b": [4, 5, 6], "grp": ["x", "x", "y"]})
+
+
+def test_select_columns():
+    table = make_table()
+    result = select(table, ["a", "grp"])
+    assert result.column_names == ["a", "grp"]
+
+
+def test_filter_rows():
+    table = make_table()
+    result = filter_rows(table, "a > 1")
+    assert result["a"].to_pylist() == [2, 3]
+
+
+def test_mutate_columns():
+    table = make_table()
+    result = mutate(table, c="a + b", b="b * 2")
+    assert result.column_names == ["a", "b", "grp", "c"]
+    assert result["b"].to_pylist() == [8, 10, 12]
+    assert result["c"].to_pylist() == [5, 7, 9]
+
+
+def test_groupby_summary():
+    table = make_table()
+    gb = groupby(table.select(["grp", "a"]), "grp", use_threads=False)
+    result = summary(gb, {"a": "sum"})
+    out = dict(zip(result["grp"].to_pylist(), result["a_sum"].to_pylist()))
+    assert out == {"x": 3, "y": 3}


### PR DESCRIPTION
## Summary
- add selection, filtering, mutation, grouping, and aggregation helpers
- expose operations in package API and declare numpy dependency
- test end-to-end table transformations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb0e57de8832aa2a00812a55a7e04