### PR TITLE
Implement basic expression parser

### DIFF
--- a/barrow/expr/__init__.py
+++ b/barrow/expr/__init__.py
@@ -1,7 +1,25 @@
 """Expression system for :mod:`barrow`.
 
-The expression module will provide a small domain specific language to
-describe column transformations.  It currently acts as a placeholder."""
+The expression module provides a small domain specific language to describe
+column transformations.
+"""
 
-__all__: list[str] = []
+from .parser import (
+    Expression,
+    Literal,
+    Name,
+    UnaryExpression,
+    BinaryExpression,
+    FunctionCall,
+    parse,
+)
 
+__all__ = [
+    "Expression",
+    "Literal",
+    "Name",
+    "UnaryExpression",
+    "BinaryExpression",
+    "FunctionCall",
+    "parse",
+]

--- a/barrow/expr/parser.py
+++ b/barrow/expr/parser.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+"""Parse simple expressions into an abstract syntax tree.
+
+The parser translates strings like ``"age > 30"`` into expression objects
+that can later be evaluated given a mapping of variable names to values.  Only
+a small subset of Python expressions is supported including arithmetic,
+comparisons, boolean operations and calls to a restricted set of functions.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+import ast
+import math
+import operator
+
+
+class Expression:
+    """Base class for all expression nodes."""
+
+    def evaluate(self, env: Mapping[str, Any]) -> Any:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class Literal(Expression):
+    value: Any
+
+    def evaluate(self, env: Mapping[str, Any]) -> Any:
+        return self.value
+
+
+@dataclass(frozen=True)
+class Name(Expression):
+    identifier: str
+
+    def evaluate(self, env: Mapping[str, Any]) -> Any:
+        return env[self.identifier]
+
+
+@dataclass(frozen=True)
+class UnaryExpression(Expression):
+    op: str
+    operand: Expression
+
+    def evaluate(self, env: Mapping[str, Any]) -> Any:
+        func = _UNARY_OPERATORS[self.op]
+        return func(self.operand.evaluate(env))
+
+
+@dataclass(frozen=True)
+class BinaryExpression(Expression):
+    left: Expression
+    op: str
+    right: Expression
+
+    def evaluate(self, env: Mapping[str, Any]) -> Any:
+        if self.op == "and":
+            return self.left.evaluate(env) and self.right.evaluate(env)
+        if self.op == "or":
+            return self.left.evaluate(env) or self.right.evaluate(env)
+        func = _BINARY_OPERATORS[self.op]
+        return func(self.left.evaluate(env), self.right.evaluate(env))
+
+
+@dataclass(frozen=True)
+class FunctionCall(Expression):
+    name: str
+    args: Sequence[Expression]
+
+    def evaluate(self, env: Mapping[str, Any]) -> Any:
+        func = env.get(self.name, _FUNCTIONS.get(self.name))
+        if func is None:
+            raise NameError(self.name)
+        return func(*(arg.evaluate(env) for arg in self.args))
+
+
+# Mapping of supported operators to their implementations
+_BINARY_OPERATORS: dict[str, Callable[[Any, Any], Any]] = {
+    "+": operator.add,
+    "-": operator.sub,
+    "*": operator.mul,
+    "/": operator.truediv,
+    "%": operator.mod,
+    "**": operator.pow,
+    "==": operator.eq,
+    "!=": operator.ne,
+    "<": operator.lt,
+    "<=": operator.le,
+    ">": operator.gt,
+    ">=": operator.ge,
+}
+
+_UNARY_OPERATORS: dict[str, Callable[[Any], Any]] = {
+    "+": operator.pos,
+    "-": operator.neg,
+    "not": operator.not_,
+}
+
+_FUNCTIONS: dict[str, Callable[..., Any]] = {
+    name: getattr(math, name) for name in dir(math) if not name.startswith("_")
+}
+_FUNCTIONS.update({"abs": abs, "max": max, "min": min})
+
+
+def parse(expression: str) -> Expression:
+    """Parse ``expression`` into an :class:`Expression` tree."""
+
+    tree = ast.parse(expression, mode="eval")
+    return _convert(tree.body)
+
+
+def _convert(node: ast.AST) -> Expression:
+    if isinstance(node, ast.BinOp):
+        op_map = {
+            ast.Add: "+",
+            ast.Sub: "-",
+            ast.Mult: "*",
+            ast.Div: "/",
+            ast.Mod: "%",
+            ast.Pow: "**",
+        }
+        return BinaryExpression(_convert(node.left), op_map[type(node.op)], _convert(node.right))
+    if isinstance(node, ast.UnaryOp):
+        op_map = {ast.Not: "not", ast.USub: "-", ast.UAdd: "+"}
+        return UnaryExpression(op_map[type(node.op)], _convert(node.operand))
+    if isinstance(node, ast.BoolOp):
+        op_map = {ast.And: "and", ast.Or: "or"}
+        expr = _convert(node.values[0])
+        for value in node.values[1:]:
+            expr = BinaryExpression(expr, op_map[type(node.op)], _convert(value))
+        return expr
+    if isinstance(node, ast.Compare):
+        if len(node.ops) != 1 or len(node.comparators) != 1:
+            raise ValueError("Chained comparisons are not supported")
+        op_map = {
+            ast.Eq: "==",
+            ast.NotEq: "!=",
+            ast.Lt: "<",
+            ast.LtE: "<=",
+            ast.Gt: ">",
+            ast.GtE: ">=",
+        }
+        return BinaryExpression(_convert(node.left), op_map[type(node.ops[0])], _convert(node.comparators[0]))
+    if isinstance(node, ast.Call):
+        if not isinstance(node.func, ast.Name):
+            raise ValueError("Only simple function calls are supported")
+        return FunctionCall(node.func.id, [_convert(arg) for arg in node.args])
+    if isinstance(node, ast.Name):
+        return Name(node.id)
+    if isinstance(node, ast.Constant):
+        return Literal(node.value)
+    raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+
+__all__ = [
+    "Expression",
+    "Literal",
+    "Name",
+    "UnaryExpression",
+    "BinaryExpression",
+    "FunctionCall",
+    "parse",
+]

--- a/tests/expr/test_parser.py
+++ b/tests/expr/test_parser.py
@@ -1,0 +1,43 @@
+import math
+
+from barrow.expr.parser import (
+    BinaryExpression,
+    FunctionCall,
+    Literal,
+    Name,
+    UnaryExpression,
+    parse,
+)
+
+
+def test_parse_simple_comparison():
+    expr = parse("age > 30")
+    expected = BinaryExpression(Name("age"), ">", Literal(30))
+    assert expr == expected
+    assert expr.evaluate({"age": 40}) is True
+    assert expr.evaluate({"age": 20}) is False
+
+
+def test_arithmetic_precedence():
+    expr = parse("a + b * 2")
+    expected = BinaryExpression(
+        Name("a"),
+        "+",
+        BinaryExpression(Name("b"), "*", Literal(2)),
+    )
+    assert expr == expected
+    assert expr.evaluate({"a": 1, "b": 3}) == 7
+
+
+def test_logical_and_function_calls():
+    expr = parse("not active or max(a, b) > 3")
+    expected = BinaryExpression(
+        UnaryExpression("not", Name("active")),
+        "or",
+        BinaryExpression(
+            FunctionCall("max", [Name("a"), Name("b")]), ">", Literal(3)
+        ),
+    )
+    assert expr == expected
+    assert expr.evaluate({"active": False, "a": 1, "b": 2}) is True
+    assert expr.evaluate({"active": True, "a": 1, "b": 2}) is False


### PR DESCRIPTION
## Summary
- add AST-based parser for simple expressions with arithmetic, logical, and function support
- expose expression parsing primitives through `barrow.expr`
- cover parser behaviour with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb216e17c832ab37b8fe2f20c5ccd