### PR TITLE
Implement custom errors and CLI handling

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
+from .errors import BarrowError
 from .io import read_table, write_table
 
 
@@ -16,8 +18,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--output", "-o", help="Output parquet file. Writes CSV to STDOUT if omitted.")
     args = parser.parse_args(argv)
 
-    table = read_table(args.input, "csv")
-    write_table(table, args.output, "parquet")
+    try:
+        table = read_table(args.input, "csv")
+        write_table(table, args.output, "parquet")
+    except BarrowError as exc:  # pragma: no cover - error path
+        print(str(exc), file=sys.stderr)
+        return 1
+
     return 0
 
 

--- a/barrow/errors.py
+++ b/barrow/errors.py
@@ -1,0 +1,21 @@
+"""Custom exceptions for the barrow project."""
+
+
+class BarrowError(Exception):
+    """Base class for all custom barrow exceptions."""
+
+
+class InvalidExpressionError(BarrowError):
+    """Raised when an expression cannot be parsed or evaluated."""
+
+
+class UnsupportedFormatError(BarrowError):
+    """Raised when an I/O function receives an unknown format."""
+
+
+__all__ = [
+    "BarrowError",
+    "InvalidExpressionError",
+    "UnsupportedFormatError",
+]
+

--- a/barrow/expr/parser.py
+++ b/barrow/expr/parser.py
@@ -14,6 +14,8 @@ import ast
 import math
 import operator
 
+from ..errors import InvalidExpressionError
+
 
 class Expression:
     """Base class for all expression nodes."""
@@ -132,7 +134,7 @@ def _convert(node: ast.AST) -> Expression:
         return expr
     if isinstance(node, ast.Compare):
         if len(node.ops) != 1 or len(node.comparators) != 1:
-            raise ValueError("Chained comparisons are not supported")
+            raise InvalidExpressionError("Chained comparisons are not supported")
         op_map = {
             ast.Eq: "==",
             ast.NotEq: "!=",
@@ -144,13 +146,13 @@ def _convert(node: ast.AST) -> Expression:
         return BinaryExpression(_convert(node.left), op_map[type(node.ops[0])], _convert(node.comparators[0]))
     if isinstance(node, ast.Call):
         if not isinstance(node.func, ast.Name):
-            raise ValueError("Only simple function calls are supported")
+            raise InvalidExpressionError("Only simple function calls are supported")
         return FunctionCall(node.func.id, [_convert(arg) for arg in node.args])
     if isinstance(node, ast.Name):
         return Name(node.id)
     if isinstance(node, ast.Constant):
         return Literal(node.value)
-    raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+    raise InvalidExpressionError(f"Unsupported expression: {ast.dump(node)}")
 
 
 __all__ = [

--- a/barrow/io/reader.py
+++ b/barrow/io/reader.py
@@ -5,6 +5,8 @@ import pyarrow as pa
 import pyarrow.csv as csv
 import pyarrow.parquet as pq
 
+from ..errors import UnsupportedFormatError
+
 
 def read_table(path: str | None, format: str) -> pa.Table:
     """Read a table from ``path`` or ``STDIN``.
@@ -27,4 +29,4 @@ def read_table(path: str | None, format: str) -> pa.Table:
             return pq.read_table(path)
         data = sys.stdin.buffer.read()
         return pq.read_table(pa.BufferReader(data))
-    raise ValueError(f"Unsupported format: {format}")
+    raise UnsupportedFormatError(f"Unsupported format: {format}")

--- a/barrow/io/writer.py
+++ b/barrow/io/writer.py
@@ -5,6 +5,8 @@ import pyarrow as pa
 import pyarrow.csv as csv
 import pyarrow.parquet as pq
 
+from ..errors import UnsupportedFormatError
+
 
 def write_table(table: pa.Table, path: str | None, format: str) -> None:
     """Write ``table`` to ``path`` or ``STDOUT``.
@@ -31,4 +33,4 @@ def write_table(table: pa.Table, path: str | None, format: str) -> None:
         else:
             pq.write_table(table, sys.stdout.buffer)
         return
-    raise ValueError(f"Unsupported format: {format}")
+    raise UnsupportedFormatError(f"Unsupported format: {format}")

--- a/tests/expr/test_parser.py
+++ b/tests/expr/test_parser.py
@@ -1,5 +1,7 @@
 import math
+import pytest
 
+from barrow.errors import InvalidExpressionError
 from barrow.expr.parser import (
     BinaryExpression,
     FunctionCall,
@@ -41,3 +43,8 @@ def test_logical_and_function_calls():
     assert expr == expected
     assert expr.evaluate({"active": False, "a": 1, "b": 2}) is True
     assert expr.evaluate({"active": True, "a": 1, "b": 2}) is False
+
+
+def test_chained_comparisons_not_supported():
+    with pytest.raises(InvalidExpressionError):
+        parse("a < b < c")

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -5,7 +5,9 @@ import io
 import sys
 
 import pyarrow as pa
+import pytest
 
+from barrow.errors import UnsupportedFormatError
 from barrow.io import read_table, write_table
 
 
@@ -41,4 +43,15 @@ def test_write_table_to_parquet(tmp_path: Path) -> None:
 
     write_table(table, str(pq_path), "parquet")
     assert pq_path.exists()
+
+
+def test_read_table_unsupported_format() -> None:
+    with pytest.raises(UnsupportedFormatError):
+        read_table("dummy", "json")
+
+
+def test_write_table_unsupported_format() -> None:
+    table = pa.table({"a": [1]})
+    with pytest.raises(UnsupportedFormatError):
+        write_table(table, "dummy", "json")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,15 @@
+from barrow.cli import main
+from barrow.errors import InvalidExpressionError
+
+
+def test_cli_returns_error_on_exception(monkeypatch, capsys) -> None:
+    def fake_read_table(path, fmt):
+        raise InvalidExpressionError("bad format")
+
+    monkeypatch.setattr("barrow.cli.read_table", fake_read_table)
+
+    rc = main(["--input", "in.csv", "--output", "out.parquet"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "bad format" in err
+


### PR DESCRIPTION
## Summary
- add BarrowError base class with InvalidExpressionError and UnsupportedFormatError
- raise custom errors from parser and I/O helpers
- handle BarrowError in CLI and test error paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcb333ff18832a95e28abea79dd9b6