### PR TITLE
Add filter and select subcommands with chaining

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -7,7 +7,9 @@ import argparse
 import sys
 
 from .errors import BarrowError
+from .expr import parse
 from .io import read_table, write_table
+from .operations import filter as op_filter, select as op_select
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -15,11 +17,37 @@ def main(argv: list[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(description="barrow: simple data tool")
     parser.add_argument("--input", "-i", help="Input CSV file. Reads STDIN if omitted.")
-    parser.add_argument("--output", "-o", help="Output parquet file. Writes CSV to STDOUT if omitted.")
-    args = parser.parse_args(argv)
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Output parquet file. Writes CSV to STDOUT if omitted.",
+    )
+    args, rest = parser.parse_known_args(argv)
 
     try:
         table = read_table(args.input, "csv")
+
+        idx = 0
+        while idx < len(rest):
+            op = rest[idx]
+            idx += 1
+            if op == "filter":
+                if idx >= len(rest):
+                    raise BarrowError("filter requires an expression")
+                expr = rest[idx]
+                idx += 1
+                parse(expr)
+                table = op_filter(table, expr)
+            elif op == "select":
+                if idx >= len(rest):
+                    raise BarrowError("select requires column names")
+                cols_arg = rest[idx]
+                idx += 1
+                cols = [c.strip() for c in cols_arg.split(",") if c.strip()]
+                table = op_select(table, cols)
+            else:  # pragma: no cover - defensive
+                raise BarrowError(f"Unknown operation: {op}")
+
         write_table(table, args.output, "parquet")
     except BarrowError as exc:  # pragma: no cover - error path
         print(str(exc), file=sys.stderr)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from barrow.cli import main
 from barrow.errors import InvalidExpressionError
+import pyarrow.parquet as pq
 
 
 def test_cli_returns_error_on_exception(monkeypatch, capsys) -> None:
@@ -12,4 +13,26 @@ def test_cli_returns_error_on_exception(monkeypatch, capsys) -> None:
     assert rc == 1
     err = capsys.readouterr().err
     assert "bad format" in err
+
+
+def test_filter_and_select(tmp_path) -> None:
+    data = b"name,age\nAlice,25\nBob,35\n"
+    src = tmp_path / "in.csv"
+    src.write_bytes(data)
+    dst = tmp_path / "out.parquet"
+
+    rc = main([
+        "--input",
+        str(src),
+        "--output",
+        str(dst),
+        "filter",
+        "age > 30",
+        "select",
+        "name,age",
+    ])
+    assert rc == 0
+    table = pq.read_table(dst)
+    assert table.column_names == ["name", "age"]
+    assert table.to_pydict() == {"name": ["Bob"], "age": [35]}
 


### PR DESCRIPTION
## Summary
- allow chaining filter and select operations in CLI
- validate expressions through parser and apply operations
- add tests for CLI chaining

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb4097ee0832a8049629f60bb509a