### PR TITLE
Add comprehensive tests with fixtures and CLI integration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import pyarrow as pa
+import pyarrow.csv as csv
+import pyarrow.parquet as pq
+import pytest
+
+
+@pytest.fixture
+def sample_table() -> pa.Table:
+    """Small example table used in tests."""
+    return pa.table({"a": [1, 2, 3], "b": [4, 5, 6], "grp": ["x", "x", "y"]})
+
+
+@pytest.fixture
+def sample_csv(tmp_path, sample_table) -> str:
+    """Path to a CSV file with ``sample_table`` data."""
+    path = tmp_path / "data.csv"
+    csv.write_csv(sample_table, path)
+    return str(path)
+
+
+@pytest.fixture
+def sample_parquet(tmp_path, sample_table) -> str:
+    """Path to a Parquet file with ``sample_table`` data."""
+    path = tmp_path / "data.parquet"
+    pq.write_table(sample_table, path)
+    return str(path)
+
+
+@pytest.fixture
+def parquet_table(sample_parquet) -> pa.Table:
+    """Table loaded from the ``sample_parquet`` fixture."""
+    return pq.read_table(sample_parquet)

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -1,4 +1,5 @@
 import pyarrow as pa
+import pytest
 
 from barrow.operations import (
     select,
@@ -9,33 +10,52 @@ from barrow.operations import (
 )
 
 
-def make_table():
-    return pa.table({"a": [1, 2, 3], "b": [4, 5, 6], "grp": ["x", "x", "y"]})
-
-
-def test_select_columns():
-    table = make_table()
-    result = select(table, ["a", "grp"])
+def test_select_columns(sample_table):
+    result = select(sample_table, ["a", "grp"])
     assert result.column_names == ["a", "grp"]
 
 
-def test_filter_rows():
-    table = make_table()
-    result = filter_rows(table, "a > 1")
+def test_select_missing_column(sample_table):
+    with pytest.raises(KeyError):
+        select(sample_table, ["a", "missing"])
+
+
+def test_filter_rows(sample_table):
+    result = filter_rows(sample_table, "a > 1")
     assert result["a"].to_pylist() == [2, 3]
 
 
-def test_mutate_columns():
-    table = make_table()
-    result = mutate(table, c="a + b", b="b * 2")
+def test_filter_invalid_expression(sample_table):
+    with pytest.raises(NameError):
+        filter_rows(sample_table, "c > 1")
+
+
+def test_mutate_columns(sample_table):
+    result = mutate(sample_table, c="a + b", b="b * 2")
     assert result.column_names == ["a", "b", "grp", "c"]
     assert result["b"].to_pylist() == [8, 10, 12]
     assert result["c"].to_pylist() == [5, 7, 9]
 
 
-def test_groupby_summary():
-    table = make_table()
-    gb = groupby(table.select(["grp", "a"]), "grp", use_threads=False)
+def test_mutate_invalid_expression(sample_table):
+    with pytest.raises(NameError):
+        mutate(sample_table, d="unknown + 1")
+
+
+def test_groupby_summary(parquet_table):
+    gb = groupby(parquet_table.select(["grp", "a"]), "grp", use_threads=False)
     result = summary(gb, {"a": "sum"})
     out = dict(zip(result["grp"].to_pylist(), result["a_sum"].to_pylist()))
     assert out == {"x": 3, "y": 3}
+
+
+def test_groupby_invalid_key(sample_table):
+    gb = groupby(sample_table, "missing", use_threads=False)
+    with pytest.raises(pa.ArrowInvalid):
+        summary(gb, {"a": "sum"})
+
+
+def test_summary_invalid_aggregation(sample_table):
+    gb = groupby(sample_table.select(["grp", "a"]), "grp", use_threads=False)
+    with pytest.raises(pa.ArrowKeyError):
+        summary(gb, {"a": "nonesuch"})


### PR DESCRIPTION
## Summary
- Provide reusable fixtures for CSV and Parquet sample data
- Extend operation tests to cover success and error cases
- Test CLI end-to-end via subprocess execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcb4df321c832ab98c8ed1948aaccb