### PR TITLE
Use parsed expressions instead of eval

### DIFF
--- a/barrow/operations/_expr_eval.py
+++ b/barrow/operations/_expr_eval.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Utilities for evaluating parsed expressions."""
+
+from typing import Any, Mapping
+
+from ..expr import Expression
+
+
+def evaluate_expression(expression: Expression, env: Mapping[str, Any]) -> Any:
+    """Evaluate *expression* using the provided *env* mapping.
+
+    Parameters
+    ----------
+    expression:
+        A parsed :class:`~barrow.expr.Expression` instance.
+    env:
+        Mapping of variable names to values and functions available during
+        evaluation.
+
+    Returns
+    -------
+    Any
+        The result of the evaluation.
+
+    Raises
+    ------
+    NameError
+        If a referenced name is not found in ``env``.
+    """
+    try:
+        return expression.evaluate(env)
+    except KeyError as exc:  # pragma: no cover - exercised in tests
+        raise NameError(str(exc)) from None

--- a/barrow/operations/filter.py
+++ b/barrow/operations/filter.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import numpy as np
 import pyarrow as pa
 
+from ..expr import Expression
+from ._expr_eval import evaluate_expression
 
-def filter(table: pa.Table, expression: str) -> pa.Table:
+
+def filter(table: pa.Table, expression: Expression) -> pa.Table:
     """Filter ``table`` by evaluating ``expression``.
 
     The expression is evaluated with a namespace containing the table's
@@ -17,7 +20,7 @@ def filter(table: pa.Table, expression: str) -> pa.Table:
         name: table[name].to_numpy(zero_copy_only=False) for name in table.column_names
     }
     env.update({name: getattr(np, name) for name in dir(np) if not name.startswith("_")})
-    mask = eval(expression, {"__builtins__": {}}, env)
+    mask = evaluate_expression(expression, env)
     return table.filter(pa.array(mask))
 
 

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -8,6 +8,7 @@ from barrow.operations import (
     groupby,
     summary,
 )
+from barrow.expr import parse
 
 
 def test_select_columns(sample_table):
@@ -21,17 +22,17 @@ def test_select_missing_column(sample_table):
 
 
 def test_filter_rows(sample_table):
-    result = filter_rows(sample_table, "a > 1")
+    result = filter_rows(sample_table, parse("a > 1"))
     assert result["a"].to_pylist() == [2, 3]
 
 
 def test_filter_invalid_expression(sample_table):
     with pytest.raises(NameError):
-        filter_rows(sample_table, "c > 1")
+        filter_rows(sample_table, parse("c > 1"))
 
 
 def test_mutate_columns(sample_table):
-    result = mutate(sample_table, c="a + b", b="b * 2")
+    result = mutate(sample_table, c=parse("a + b"), b=parse("b * 2"))
     assert result.column_names == ["a", "b", "grp", "c"]
     assert result["b"].to_pylist() == [8, 10, 12]
     assert result["c"].to_pylist() == [5, 7, 9]
@@ -39,7 +40,7 @@ def test_mutate_columns(sample_table):
 
 def test_mutate_invalid_expression(sample_table):
     with pytest.raises(NameError):
-        mutate(sample_table, d="unknown + 1")
+        mutate(sample_table, d=parse("unknown + 1"))
 
 
 def test_groupby_summary(parquet_table):


### PR DESCRIPTION
## Summary
- Replace Python `eval` calls with parsed expression evaluation via new `evaluate_expression` helper
- Update filter and mutate operations to accept `Expression` instances
- Parse expressions in CLI and tests before invoking operations

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd93ff4b6c832ab4fbbdcc587187f1