### PR TITLE
Add parser and function error tests

### DIFF
--- a/tests/expr/test_parse_errors.py
+++ b/tests/expr/test_parse_errors.py
@@ -1,0 +1,20 @@
+import pytest
+
+from barrow.errors import InvalidExpressionError
+from barrow.expr import parse
+
+
+def test_parse_invalid_syntax():
+    with pytest.raises(SyntaxError):
+        parse("a +")
+
+
+def test_parse_attribute_call_not_supported():
+    with pytest.raises(InvalidExpressionError):
+        parse("obj.method()")
+
+
+def test_parse_conditional_expression_not_supported():
+    with pytest.raises(InvalidExpressionError):
+        parse("a if b else c")
+

--- a/tests/expr/test_placeholder.py
+++ b/tests/expr/test_placeholder.py
@@ -1,3 +1,0 @@
-def test_expr_placeholder():
-    assert True
-

--- a/tests/operations/test_operations.py
+++ b/tests/operations/test_operations.py
@@ -60,3 +60,16 @@ def test_summary_invalid_aggregation(sample_table):
     gb = groupby(sample_table.select(["grp", "a"]), "grp", use_threads=False)
     with pytest.raises(pa.ArrowKeyError):
         summary(gb, {"a": "nonesuch"})
+
+
+def test_filter_unknown_function(sample_table):
+    expr = parse("nosuch(a)")
+    with pytest.raises(NameError):
+        filter_rows(sample_table, expr)
+
+
+def test_mutate_unknown_function(sample_table):
+    expr = parse("nosuch(a)")
+    with pytest.raises(NameError):
+        mutate(sample_table, d=expr)
+

--- a/tests/operations/test_placeholder.py
+++ b/tests/operations/test_placeholder.py
@@ -1,3 +1,0 @@
-def test_operations_placeholder():
-    assert True
-


### PR DESCRIPTION
## Summary
- replace placeholder tests with meaningful coverage
- add parser error tests for invalid syntax and unsupported constructs
- check filter and mutate handle unknown functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be081ce788832abe9f09623fb003f2