### PR TITLE
Add DuckDB-backed SQL operation

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -18,6 +18,7 @@ from .operations import (
     summary as op_summary,
     join as op_join,
     window as op_window,
+    sql as op_sql,
 )
 
 
@@ -105,6 +106,12 @@ def main(argv: list[str] | None = None) -> int:
                     idx += 1
                 right_table = read_table(path, args.input_format)
                 table = op_join(table, right_table, left_on, right_on, join_type)
+            elif op == "sql":
+                if idx >= len(rest):
+                    raise BarrowError("sql requires a query")
+                query = rest[idx]
+                idx += 1
+                table = op_sql(table, query)
             elif op == "groupby":
                 if idx >= len(rest):
                     raise BarrowError("groupby requires column names")

--- a/barrow/operations/__init__.py
+++ b/barrow/operations/__init__.py
@@ -12,6 +12,7 @@ from .groupby import groupby
 from .summary import summary
 from .join import join
 from .window import window
+from .sql import sql
 
-__all__ = ["select", "filter", "mutate", "groupby", "summary", "join", "window"]
+__all__ = ["select", "filter", "mutate", "groupby", "summary", "join", "window", "sql"]
 

--- a/barrow/operations/sql.py
+++ b/barrow/operations/sql.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Execute SQL queries using DuckDB."""
+
+import duckdb
+import pyarrow as pa
+
+
+def sql(table: pa.Table, query: str) -> pa.Table:
+    """Return the result of *query* executed against *table*.
+
+    The input table is registered as a view named ``tbl`` and the query is
+    evaluated using DuckDB, returning the result as a new :class:`pa.Table`.
+    """
+    con = duckdb.connect()
+    try:
+        con.register("tbl", table)
+        return con.execute(query).arrow()
+    finally:
+        con.close()
+
+
+__all__ = ["sql"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [{name = "Barrow Developers"}]
 dependencies = [
     "pyarrow",
     "numpy",
+    "duckdb",
 ]
 
 [project.scripts]

--- a/tests/operations/test_sql.py
+++ b/tests/operations/test_sql.py
@@ -1,0 +1,30 @@
+import duckdb
+import pytest
+
+import pyarrow as pa
+
+from barrow.operations import sql
+
+
+def test_simple_query(sample_table: pa.Table) -> None:
+    result = sql(sample_table, "SELECT a FROM tbl")
+    assert result.column_names == ["a"]
+    assert result["a"].to_pylist() == [1, 2, 3]
+
+
+def test_filtering(sample_table: pa.Table) -> None:
+    result = sql(sample_table, "SELECT * FROM tbl WHERE a > 1")
+    assert result["a"].to_pylist() == [2, 3]
+
+
+def test_aggregation(sample_table: pa.Table) -> None:
+    result = sql(
+        sample_table,
+        "SELECT grp, SUM(a) AS s FROM tbl GROUP BY grp ORDER BY grp",
+    )
+    assert result.to_pydict() == {"grp": ["x", "y"], "s": [3, 3]}
+
+
+def test_syntax_error(sample_table: pa.Table) -> None:
+    with pytest.raises(duckdb.ParserException):
+        sql(sample_table, "SELEKT * FROM tbl")


### PR DESCRIPTION
## Summary
- add DuckDB as a dependency
- expose new `sql` operation for running SQL queries
- wire `sql` into CLI and export from operations package
- cover SQL queries, filtering, aggregation and syntax errors in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be28849528832a93e1ccaee60c5b66