### PR TITLE
feat: add grouping metadata and ungroup operation

### DIFF
--- a/barrow/operations/__init__.py
+++ b/barrow/operations/__init__.py
@@ -10,9 +10,20 @@ from .filter import filter
 from .mutate import mutate
 from .groupby import groupby
 from .summary import summary
+from .ungroup import ungroup
 from .join import join
 from .window import window
 from .sql import sql
 
-__all__ = ["select", "filter", "mutate", "groupby", "summary", "join", "window", "sql"]
+__all__ = [
+    "select",
+    "filter",
+    "mutate",
+    "groupby",
+    "summary",
+    "ungroup",
+    "join",
+    "window",
+    "sql",
+]
 

--- a/barrow/operations/groupby.py
+++ b/barrow/operations/groupby.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import pyarrow as pa
 
 
-def groupby(table: pa.Table, keys: str | list[str], *, use_threads: bool = True) -> pa.TableGroupBy:
-    """Group ``table`` by ``keys``.
-
-    This is a thin wrapper over :meth:`pyarrow.Table.group_by` that exposes the
-    ``use_threads`` parameter for deterministic testing.
-    """
-    return table.group_by(keys, use_threads=use_threads)
+def groupby(table: pa.Table, keys: str | list[str]) -> pa.Table:
+    """Return ``table`` tagged with grouping metadata for ``keys``."""
+    if isinstance(keys, str):
+        keys = [keys]
+    metadata = dict(table.schema.metadata or {})
+    metadata[b"grouped_by"] = ",".join(keys).encode()
+    return table.replace_schema_metadata(metadata)
 
 
 __all__ = ["groupby"]

--- a/barrow/operations/summary.py
+++ b/barrow/operations/summary.py
@@ -6,18 +6,22 @@ from collections.abc import Mapping
 
 import pyarrow as pa
 
+from ..errors import BarrowError
 
-def summary(grouped: pa.TableGroupBy, aggregations: Mapping[str, str] | None = None, **kwargs: str) -> pa.Table:
-    """Aggregate ``grouped`` according to ``aggregations``.
 
-    Aggregations can be passed either as a mapping or as keyword arguments where
-    keys are column names and values are the aggregation function (e.g. ``"sum"``).
-    """
+def summary(table: pa.Table, aggregations: Mapping[str, str] | None = None, **kwargs: str) -> pa.Table:
+    """Aggregate ``table`` according to ``aggregations`` using grouping metadata."""
+    metadata = table.schema.metadata or {}
+    grouped_by = metadata.get(b"grouped_by")
+    if not grouped_by:
+        raise BarrowError("summary requires grouping metadata")
+    keys = grouped_by.decode().split(",") if grouped_by else []
     if aggregations is None:
         aggregations = {}
     aggregations = {**aggregations, **kwargs}
     pairs = list(aggregations.items())
-    return grouped.aggregate(pairs)
+    result = table.group_by(keys).aggregate(pairs)
+    return result.replace_schema_metadata(metadata)
 
 
 __all__ = ["summary"]

--- a/barrow/operations/ungroup.py
+++ b/barrow/operations/ungroup.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Remove grouping metadata from a table."""
+
+import pyarrow as pa
+
+
+def ungroup(table: pa.Table) -> pa.Table:
+    """Return ``table`` without grouping metadata."""
+    metadata = dict(table.schema.metadata or {})
+    metadata.pop(b"grouped_by", None)
+    return table.replace_schema_metadata(metadata or None)
+
+
+__all__ = ["ungroup"]


### PR DESCRIPTION
## Summary
- support grouping metadata via new `groupby` and `summary` implementations
- add `ungroup` operation and CLI subcommand
- simplify CLI groupby/summary commands to rely on operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be3dba4840832a89d6f3dff936e341