### PR TITLE
Improve error handling for missing names in expressions

### DIFF
--- a/barrow/operations/_expr_eval.py
+++ b/barrow/operations/_expr_eval.py
@@ -30,5 +30,9 @@ def evaluate_expression(expression: Expression, env: Mapping[str, Any]) -> Any:
     """
     try:
         return expression.evaluate(env)
-    except KeyError as exc:  # pragma: no cover - exercised in tests
-        raise NameError(str(exc)) from None
+    except (KeyError, NameError) as exc:  # pragma: no cover - exercised in tests
+        # ``KeyError`` occurs for missing variables while a ``NameError``
+        # can be raised for missing functions.  Include the missing name
+        # in the error message for clarity.
+        missing = exc.args[0]
+        raise NameError(f"name '{missing}' is not defined") from None

--- a/tests/expr/test_parse_errors.py
+++ b/tests/expr/test_parse_errors.py
@@ -2,19 +2,37 @@ import pytest
 
 from barrow.errors import InvalidExpressionError
 from barrow.expr import parse
+from barrow.operations._expr_eval import evaluate_expression
 
 
 def test_parse_invalid_syntax():
-    with pytest.raises(SyntaxError):
+    with pytest.raises(SyntaxError) as excinfo:
         parse("a +")
+    assert "invalid syntax" in str(excinfo.value)
 
 
 def test_parse_attribute_call_not_supported():
-    with pytest.raises(InvalidExpressionError):
+    with pytest.raises(InvalidExpressionError) as excinfo:
         parse("obj.method()")
+    assert "Only simple function calls are supported" in str(excinfo.value)
 
 
 def test_parse_conditional_expression_not_supported():
-    with pytest.raises(InvalidExpressionError):
+    with pytest.raises(InvalidExpressionError) as excinfo:
         parse("a if b else c")
+    assert "Unsupported expression" in str(excinfo.value)
+
+
+def test_missing_variable_name_in_error():
+    expr = parse("a + 1")
+    with pytest.raises(NameError) as excinfo:
+        evaluate_expression(expr, {})
+    assert "name 'a' is not defined" in str(excinfo.value)
+
+
+def test_missing_function_name_in_error():
+    expr = parse("unknown_func(1)")
+    with pytest.raises(NameError) as excinfo:
+        evaluate_expression(expr, {})
+    assert "name 'unknown_func' is not defined" in str(excinfo.value)
 


### PR DESCRIPTION
## Summary
- Provide clearer NameError messages by including missing variable or function name during expression evaluation
- Expand parse error tests to validate messages and cover undefined variables and functions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be49947a00832a8eb1ec181a3004a8