### PR TITLE
Add development extras and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Commands read from files or `STDIN` and write to files or `STDOUT` in CSV or Par
 pip install barrow
 ```
 
+For a development install with linting and testing tools:
+
+```bash
+pip install -e .[dev]
+```
+
 ## Usage
 All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and `--output-format` to control I/O. These options support `csv` or `parquet`. When omitted, formats are inferred from file extensions or magic bytes when reading from `STDIN`. Leaving out `--input` makes the command read from `STDIN`; omitting `--output` writes to `STDOUT`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,16 @@ dependencies = [
     "duckdb",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pre-commit",
+    "ruff",
+    "black",
+    "mypy",
+    "argcomplete",
+]
+
 [project.scripts]
 barrow = "barrow.cli:main"
 


### PR DESCRIPTION
## Summary
- add `dev` extras group with common tooling
- document `pip install -e .[dev]` for development setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be51a1a41c832a81532bb6765d875f