### PR TITLE
Add pre-commit hooks and setup instructions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.0
+    hooks:
+      - id: ruff
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+      - id: mypy
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ For a development install with linting and testing tools:
 
 ```bash
 pip install -e .[dev]
+pre-commit install
 ```
+
+Running `pre-commit install` sets up the git hooks for linting, formatting, type checking, and quick tests.
 
 ## Usage
 All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and `--output-format` to control I/O. These options support `csv` or `parquet`. When omitted, formats are inferred from file extensions or magic bytes when reading from `STDIN`. Leaving out `--input` makes the command read from `STDIN`; omitting `--output` writes to `STDOUT`.


### PR DESCRIPTION
## Summary
- add pre-commit config with ruff, black, mypy, and pytest hooks
- document `pre-commit install` for developers

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') stderr: HTTP 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be53a6e4c8832ab54f508e1654418f