### PR TITLE
Add Makefile and document development workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing
+
+## Setup
+
+Use the provided Makefile to install development dependencies and pre-commit hooks:
+
+```bash
+make install
+```
+
+## Development workflow
+
+Run linters and formatters:
+
+```bash
+make lint
+make format
+```
+
+Run the test suite:
+
+```bash
+make test
+```
+
+Clean up generated files:
+
+```bash
+make clean
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: install lint test format clean
+
+install:
+	pip install -e .[dev]
+	pre-commit install
+
+lint:
+	pre-commit run --all-files
+
+test:
+	pytest
+
+format:
+	pre-commit run --all-files
+
+clean:
+	rm -rf .pytest_cache .mypy_cache .ruff_cache
+	find . -type d -name __pycache__ -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -11,11 +11,19 @@ pip install barrow
 For a development install with linting and testing tools:
 
 ```bash
-pip install -e .[dev]
-pre-commit install
+make install
 ```
 
-Running `pre-commit install` sets up the git hooks for linting, formatting, type checking, and quick tests.
+`make install` installs development dependencies and configures pre-commit hooks.
+
+The Makefile also provides common tasks:
+
+```bash
+make lint    # run linters via pre-commit
+make format  # format code via pre-commit
+make test    # run the test suite
+make clean   # remove build artifacts
+```
 
 ## Usage
 All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and `--output-format` to control I/O. These options support `csv` or `parquet`. When omitted, formats are inferred from file extensions or magic bytes when reading from `STDIN`. Leaving out `--input` makes the command read from `STDIN`; omitting `--output` writes to `STDOUT`.
@@ -72,7 +80,7 @@ These pipelines demonstrate reading from `STDIN` and writing to `STDOUT` while c
 Run the test suite with:
 
 ```bash
-pytest
+make test
 ```
 
 Optional dependencies:


### PR DESCRIPTION
## Summary
- add Makefile with install, lint, test, format, and clean targets
- document Makefile usage in README and CONTRIBUTING guidelines

## Testing
- `pre-commit run --files Makefile README.md CONTRIBUTING.md` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'); return code: 128)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be5625f5e8832ab996509756c6e087