### PR TITLE
Add documentation and MkDocs setup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+name: Docs
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[docs]
+      - name: Build documentation
+        run: mkdocs build --strict
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[docs]
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,25 @@
+# Installation
+
+## Prerequisites
+- Python 3.11 or later
+- [DuckDB](https://duckdb.org/) and [Apache Arrow](https://arrow.apache.org/) are required. They are installed automatically when using `pip` but can also be installed system wide for optimal performance.
+
+## Install from PyPI
+```bash
+pip install barrow
+```
+This command installs `barrow` along with its core dependencies such as `pyarrow`, `duckdb` and `numpy`.
+
+## Development Install
+For contributing or running the test suite, install the optional development and documentation dependencies:
+```bash
+pip install -e .[dev,docs]
+```
+This installs linting tools, test runners and documentation tooling like MkDocs.
+
+## Verifying the Installation
+After installation, verify that the CLI works:
+```bash
+barrow --help
+```
+The command should print the top-level help screen describing available subcommands.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,30 @@
+# Usage
+
+`barrow` operates on tabular data using a pipeline of commands connected with standard Unix pipes.
+
+## Basic Concepts
+Each command reads from `STDIN` or a file and writes to `STDOUT` or a file. Formats are inferred from file extensions or may be specified explicitly with `--input-format` and `--output-format`.
+
+## Advanced Examples
+### Join and Aggregate
+```bash
+barrow join id id --right other.csv --input data.csv | \
+barrow mutate "total=price*qty" | \
+barrow groupby category | \
+barrow summary "revenue=sum(total)" --output-format parquet --output report.parquet
+```
+This pipeline joins two datasets on `id`, computes a new column, groups by `category`, and writes aggregated revenue to a Parquet file.
+
+### Streaming Filters and Projections
+```bash
+barrow filter "score > 80" --input-format csv | \
+barrow select "name,score" | \
+barrow sort "score" --descending
+```
+Use streaming operations to filter, project, and sort large datasets without loading them entirely into memory.
+
+## Performance Tips
+- Prefer the Parquet format for large datasets to leverage Arrow's columnar layout.
+- Provide explicit `--input-format` and `--output-format` to avoid format detection overhead.
+- Use `select` early in pipelines to reduce the number of processed columns.
+- When possible, install DuckDB and Arrow libraries with SIMD support for better throughput.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: Barrow
+nav:
+  - Installation: installation.md
+  - Usage: usage.md
+docs_dir: docs
+theme:
+  name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,24 @@ dev = [
     "mypy",
     "argcomplete",
 ]
+docs = [
+    "mkdocs>=1.5",
+    "mkdocs-material",
+]
 
 [project.scripts]
 barrow = "barrow.cli:main"
 
+
+[tool.mkdocs]
+site_name = "Barrow"
+docs_dir = "docs"
+
+[[tool.mkdocs.nav]]
+Installation = "installation.md"
+
+[[tool.mkdocs.nav]]
+Usage = "usage.md"
+
+[tool.mkdocs.theme]
+name = "material"


### PR DESCRIPTION
## Summary
- Add installation and usage guides in `docs/`
- Configure MkDocs and optional docs dependencies
- Publish docs via GitHub Pages workflow

## Testing
- `mkdocs build`
- `pre-commit run --files docs/installation.md docs/usage.md pyproject.toml mkdocs.yml .github/workflows/docs.yml` *(failed: RPC failed; HTTP 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be59570bb0832a8c028bc55fe4849e