### PR TITLE
Integrate Commitizen and automate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: ["main"]
+    tags: ["v*.*.*"]
   pull_request:
     branches: ["main"]
 
@@ -25,3 +26,21 @@ jobs:
         run: pre-commit run --all-files
       - name: Run tests
         run: pytest
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Build package
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,18 @@ Remove generated files:
 ```bash
 make clean
 ```
+
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/), using
+`MAJOR.MINOR.PATCH` numbers to indicate backward-incompatible changes, new
+features, and bug fixes respectively. Releases and the changelog are managed
+with [Commitizen](https://commitizen-tools.github.io/commitizen/). When you're
+ready to cut a new release, run:
+
+```bash
+cz bump
+```
+
+This command updates version numbers and the `CHANGELOG.md` based on commit
+messages that follow the Conventional Commits specification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "black",
     "mypy",
     "argcomplete",
+    "commitizen",
 ]
 docs = [
     "mkdocs>=1.5",
@@ -46,3 +47,14 @@ Usage = "usage.md"
 
 [tool.mkdocs.theme]
 name = "material"
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.1.0"
+tag_format = "v$version"
+version_files = [
+    "pyproject.toml:version",
+    "barrow/__init__.py:__version__",
+]
+update_changelog_on_bump = true
+changelog_file = "CHANGELOG.md"


### PR DESCRIPTION
## Summary
- configure Commitizen for version bumping and changelog generation
- add release job to CI to publish tagged versions to PyPI
- document semantic versioning and Commitizen workflow

## Testing
- `pre-commit run --files pyproject.toml .github/workflows/ci.yml CONTRIBUTING.md CHANGELOG.md` (failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be5a649ce4832a97e056b44e57186a