### PR TITLE
Add Docker and local env setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+
+.venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir .
+ENTRYPOINT ["barrow"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ make install
 
 `make install` installs development dependencies and configures pre-commit hooks.
 
+To create an isolated environment with autocompletion, run:
+```bash
+source scripts/setup_env.sh
+```
+A minimal Dockerfile is available for container usage:
+```bash
+docker build -t barrow .
+docker run --rm barrow --help
+```
+
 The Makefile also provides common tasks:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,20 @@ pip install -e .[dev,docs]
 ```
 This installs linting tools, test runners and documentation tooling like MkDocs.
 
+## Using the setup script
+To create an isolated development environment with shell completion, run:
+```bash
+source scripts/setup_env.sh
+```
+This creates a virtual environment in `.venv`, installs development dependencies and enables `barrow` tab completion for the current shell.
+
+## Running with Docker
+A minimal Dockerfile is provided to run `barrow` in a container:
+```bash
+docker build -t barrow .
+docker run --rm -it barrow --help
+```
+
 ## Verifying the Installation
 After installation, verify that the CLI works:
 ```bash

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e .[dev]
+
+# Enable argcomplete for the current shell
+eval "$(register-python-argcomplete barrow)"
+
+echo "Virtual environment created and completion enabled."


### PR DESCRIPTION
## Summary
- provide minimal Dockerfile with barrow entrypoint
- add setup script that creates venv and enables argcomplete
- document Docker and setup script usage in installation docs and README

## Testing
- `pre-commit run --files Dockerfile scripts/setup_env.sh docs/installation.md README.md .gitignore` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') with HTTP 403)*
- `pytest`
- `bash -n scripts/setup_env.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be5b5602bc832abb6426db4b333b21