### PR TITLE
refactor: enforce top-level imports

### DIFF
--- a/barrow/expr/parser.py
+++ b/barrow/expr/parser.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Parse simple expressions into an abstract syntax tree.
 
 The parser translates strings like ``"age > 30"`` into expression objects
@@ -8,14 +6,16 @@ a small subset of Python expressions is supported including arithmetic,
 comparisons, boolean operations and calls to a restricted set of functions.
 """
 
-from dataclasses import dataclass
-from typing import Any, Callable, Mapping, Sequence
+from __future__ import annotations
+
 import ast
 import math
 import operator
 import re
 import tokenize
+from dataclasses import dataclass
 from io import StringIO
+from typing import Any, Callable, Mapping, Sequence
 
 from ..errors import InvalidExpressionError
 
@@ -122,7 +122,9 @@ def _replace_like_tokens(expression: str) -> str:
     new_tokens = []
     for tok in tokens:
         if tok.type == tokenize.NAME and tok.string == "like":
-            new_tokens.append(tokenize.TokenInfo(tokenize.OP, "@", tok.start, tok.end, tok.line))
+            new_tokens.append(
+                tokenize.TokenInfo(tokenize.OP, "@", tok.start, tok.end, tok.line)
+            )
         else:
             new_tokens.append(tok)
     return tokenize.untokenize(new_tokens)
@@ -147,7 +149,9 @@ def _convert(node: ast.AST) -> Expression:
             ast.Pow: "**",
             ast.MatMult: "like",
         }
-        return BinaryExpression(_convert(node.left), op_map[type(node.op)], _convert(node.right))
+        return BinaryExpression(
+            _convert(node.left), op_map[type(node.op)], _convert(node.right)
+        )
     if isinstance(node, ast.UnaryOp):
         op_map = {ast.Not: "not", ast.USub: "-", ast.UAdd: "+"}
         return UnaryExpression(op_map[type(node.op)], _convert(node.operand))
@@ -170,7 +174,11 @@ def _convert(node: ast.AST) -> Expression:
             ast.In: "in",
             ast.NotIn: "not in",
         }
-        return BinaryExpression(_convert(node.left), op_map[type(node.ops[0])], _convert(node.comparators[0]))
+        return BinaryExpression(
+            _convert(node.left),
+            op_map[type(node.ops[0])],
+            _convert(node.comparators[0]),
+        )
     if isinstance(node, ast.Call):
         if not isinstance(node.func, ast.Name):
             raise InvalidExpressionError("Only simple function calls are supported")

--- a/barrow/operations/_env.py
+++ b/barrow/operations/_env.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Common environment for expression evaluation."""
+
+from __future__ import annotations
 
 import numpy as np
 import pyarrow as pa
@@ -14,12 +14,12 @@ def build_env(table: pa.Table) -> dict[str, object]:
     """
 
     env: dict[str, object] = {
-        name: table[name].to_numpy(zero_copy_only=False)
-        for name in table.column_names
+        name: table[name].to_numpy(zero_copy_only=False) for name in table.column_names
     }
-    env.update({name: getattr(np, name) for name in dir(np) if not name.startswith("_")})
+    env.update(
+        {name: getattr(np, name) for name in dir(np) if not name.startswith("_")}
+    )
     return env
 
 
 __all__ = ["build_env"]
-

--- a/barrow/operations/_expr_eval.py
+++ b/barrow/operations/_expr_eval.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utilities for evaluating parsed expressions."""
+
+from __future__ import annotations
 
 from typing import Any, Mapping
 

--- a/barrow/operations/filter.py
+++ b/barrow/operations/filter.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Row filtering operation using Python expressions."""
+
+from __future__ import annotations
 
 import pyarrow as pa
 

--- a/barrow/operations/groupby.py
+++ b/barrow/operations/groupby.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Grouping utilities."""
+
+from __future__ import annotations
 
 import pyarrow as pa
 

--- a/barrow/operations/join.py
+++ b/barrow/operations/join.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Table join operation."""
+
+from __future__ import annotations
 
 import pyarrow as pa
 

--- a/barrow/operations/mutate.py
+++ b/barrow/operations/mutate.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Column creation and transformation operation."""
+
+from __future__ import annotations
 
 import pyarrow as pa
 

--- a/barrow/operations/select.py
+++ b/barrow/operations/select.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Column selection operation."""
+
+from __future__ import annotations
 
 import pyarrow as pa
 

--- a/barrow/operations/sql.py
+++ b/barrow/operations/sql.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Execute SQL queries using DuckDB."""
+
+from __future__ import annotations
 
 import duckdb
 import pyarrow as pa

--- a/barrow/operations/summary.py
+++ b/barrow/operations/summary.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Aggregation helpers for grouped tables."""
+
+from __future__ import annotations
 
 from collections.abc import Mapping
 
@@ -9,7 +9,9 @@ import pyarrow as pa
 from ..errors import BarrowError
 
 
-def summary(table: pa.Table, aggregations: Mapping[str, str] | None = None, **kwargs: str) -> pa.Table:
+def summary(
+    table: pa.Table, aggregations: Mapping[str, str] | None = None, **kwargs: str
+) -> pa.Table:
     """Aggregate ``table`` according to ``aggregations`` using grouping metadata."""
     metadata = table.schema.metadata or {}
     grouped_by = metadata.get(b"grouped_by")

--- a/barrow/operations/ungroup.py
+++ b/barrow/operations/ungroup.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Remove grouping metadata from a table."""
+
+from __future__ import annotations
 
 import pyarrow as pa
 

--- a/barrow/operations/window.py
+++ b/barrow/operations/window.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Window functions for :mod:`barrow`."""
+
+from __future__ import annotations
 
 import numpy as np
 import pyarrow as pa
@@ -68,7 +68,9 @@ def window(
         offsets = [0, n]
 
     # Environment for expression evaluation (sorted order)
-    env: dict[str, pa.Array] = {name: sorted_table[name] for name in sorted_table.column_names}
+    env: dict[str, pa.Array] = {
+        name: sorted_table[name] for name in sorted_table.column_names
+    }
 
     def row_number() -> pa.Array:
         out = np.empty(n, dtype=np.int64)
@@ -96,14 +98,16 @@ def window(
             denom[start:stop] = np.minimum(np.arange(1, length + 1), window)
         return pa.array(rs / denom)
 
-    env.update({
-        name: getattr(pc, name) for name in dir(pc) if not name.startswith("_")
-    })
-    env.update({
-        "row_number": row_number,
-        "rolling_sum": rolling_sum,
-        "rolling_mean": rolling_mean,
-    })
+    env.update(
+        {name: getattr(pc, name) for name in dir(pc) if not name.startswith("_")}
+    )
+    env.update(
+        {
+            "row_number": row_number,
+            "rolling_sum": rolling_sum,
+            "rolling_mean": rolling_mean,
+        }
+    )
 
     out = table
     for name, expr in expressions.items():


### PR DESCRIPTION
## Summary
- reorder imports so all modules start with docstring, `from __future__` and imports
- ensure parser and operations modules contain no top-level code before imports

## Testing
- `ruff check --select E402 barrow/expr/parser.py barrow/operations/_env.py barrow/operations/_expr_eval.py barrow/operations/filter.py barrow/operations/groupby.py barrow/operations/join.py barrow/operations/mutate.py barrow/operations/select.py barrow/operations/sql.py barrow/operations/summary.py barrow/operations/ungroup.py barrow/operations/window.py`
- `black --check barrow/expr/parser.py barrow/operations/_env.py barrow/operations/_expr_eval.py barrow/operations/filter.py barrow/operations/groupby.py barrow/operations/join.py barrow/operations/mutate.py barrow/operations/select.py barrow/operations/sql.py barrow/operations/summary.py barrow/operations/ungroup.py barrow/operations/window.py`
- `mypy barrow/expr/parser.py barrow/operations/_env.py barrow/operations/_expr_eval.py barrow/operations/filter.py barrow/operations/groupby.py barrow/operations/join.py barrow/operations/mutate.py barrow/operations/select.py barrow/operations/sql.py barrow/operations/summary.py barrow/operations/ungroup.py barrow/operations/window.py` (fails: Skipping analyzing "pyarrow": module is installed, but missing library stubs or py.typed marker)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bed83b4af0832ab082aa80eb25b1cf