### PR TITLE
tests: remove unused imports

### DIFF
--- a/tests/expr/test_parser.py
+++ b/tests/expr/test_parser.py
@@ -1,4 +1,3 @@
-import math
 import pytest
 
 from barrow.errors import InvalidExpressionError
@@ -36,9 +35,7 @@ def test_logical_and_function_calls():
     expected = BinaryExpression(
         UnaryExpression("not", Name("active")),
         "or",
-        BinaryExpression(
-            FunctionCall("max", [Name("a"), Name("b")]), ">", Literal(3)
-        ),
+        BinaryExpression(FunctionCall("max", [Name("a"), Name("b")]), ">", Literal(3)),
     )
     assert expr == expected
     assert expr.evaluate({"active": False, "a": 1, "b": 2}) is True
@@ -58,10 +55,10 @@ def test_membership_operators():
     assert expr.evaluate({"age": 25}) is False
 
     expr = parse("country not in ['US', 'CA']")
-    expected = BinaryExpression(Name("country"), "not in", Literal(['US', 'CA']))
+    expected = BinaryExpression(Name("country"), "not in", Literal(["US", "CA"]))
     assert expr == expected
-    assert expr.evaluate({"country": 'US'}) is False
-    assert expr.evaluate({"country": 'FR'}) is True
+    assert expr.evaluate({"country": "US"}) is False
+    assert expr.evaluate({"country": "FR"}) is True
 
 
 def test_like_operator():

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -5,7 +5,6 @@ import io
 import sys
 
 import pyarrow as pa
-import pyarrow.csv as csv
 import pyarrow.parquet as pq
 import pytest
 
@@ -76,4 +75,3 @@ def test_write_table_unsupported_format() -> None:
     table = pa.table({"a": [1]})
     with pytest.raises(UnsupportedFormatError):
         write_table(table, "dummy", "json")
-

--- a/tests/operations/test_window.py
+++ b/tests/operations/test_window.py
@@ -1,4 +1,3 @@
-import pyarrow as pa
 import pytest
 
 from barrow.expr import parse
@@ -11,7 +10,9 @@ def test_row_number(sample_table):
 
 
 def test_rolling_mean(sample_table):
-    result = window(sample_table, by=["grp"], order_by=["a"], ma=parse("rolling_mean(a, 2)"))
+    result = window(
+        sample_table, by=["grp"], order_by=["a"], ma=parse("rolling_mean(a, 2)")
+    )
     out = [round(x, 3) for x in result["ma"].to_pylist()]
     assert out == [1.0, 1.5, 3.0]
 


### PR DESCRIPTION
## Summary
- remove unused math import from parser tests
- drop unused pyarrow.csv import in io tests
- clean up unused pyarrow import in window tests

## Testing
- `ruff check tests/expr/test_parser.py tests/io/test_io.py tests/operations/test_window.py`
- `black tests/expr/test_parser.py tests/io/test_io.py tests/operations/test_window.py`
- `mypy tests/expr/test_parser.py tests/io/test_io.py tests/operations/test_window.py` (fails: missing pyarrow stubs)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bedd17db04832ab1772efc679f99f7