### PR TITLE
refactor: clarify literal element handling

### DIFF
--- a/barrow/expr/parser.py
+++ b/barrow/expr/parser.py
@@ -195,8 +195,8 @@ def _convert(node: ast.AST) -> Expression:
         elements = [_convert(e) for e in node.elts]
         if not all(isinstance(e, Literal) for e in elements):
             raise InvalidExpressionError("Only literal sequences are supported")
-        lit_elements = cast(list[Literal], elements)
-        values = [e.value for e in lit_elements]
+        typed_elements = cast(list[Literal], elements)
+        values = [e.value for e in typed_elements]
         if isinstance(node, ast.List):
             return Literal(values)
         if isinstance(node, ast.Tuple):


### PR DESCRIPTION
## Summary
- rename `lit_elements` to `typed_elements` and cast to list of `Literal`
- extract literal values from typed elements

## Testing
- `pre-commit run --files barrow/expr/parser.py` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') return code: 128)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bee3910f8c832a9aeb6893e6f2a851