### PR TITLE
refactor tests for clarity

### DIFF
--- a/tests/expr/test_parser.py
+++ b/tests/expr/test_parser.py
@@ -47,13 +47,15 @@ def test_chained_comparisons_not_supported():
         parse("a < b < c")
 
 
-def test_membership_operators():
+def test_in_operator():
     expr = parse("age in [20, 30]")
     expected = BinaryExpression(Name("age"), "in", Literal([20, 30]))
     assert expr == expected
     assert expr.evaluate({"age": 20}) is True
     assert expr.evaluate({"age": 25}) is False
 
+
+def test_not_in_operator():
     expr = parse("country not in ['US', 'CA']")
     expected = BinaryExpression(Name("country"), "not in", Literal(["US", "CA"]))
     assert expr == expected


### PR DESCRIPTION
## Summary
- split membership operator tests into distinct cases
- parameterize CLI format tests for clearer failures

## Testing
- `pre-commit run --files tests/test_cli.py tests/expr/test_parser.py` *(fails: RPC failed; HTTP 403 curl 22)*
- `pytest tests/expr/test_parser.py tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68bec1b4d838832aa570c17311d39ca6