### PR TITLE
Add debug logging to operations and tests

### DIFF
--- a/barrow/operations/filter.py
+++ b/barrow/operations/filter.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import pyarrow as pa
 
 from ..expr import Expression
 from ._env import build_env
 from ._expr_eval import evaluate_expression
+
+
+logger = logging.getLogger(__name__)
 
 
 def filter(table: pa.Table, expression: Expression) -> pa.Table:
@@ -16,9 +20,13 @@ def filter(table: pa.Table, expression: Expression) -> pa.Table:
     columns and functions from :mod:`numpy` provided by
     :func:`~barrow.operations._env.build_env`.
     """
+    logger.debug("Filtering with expression %s", expression)
     env = build_env(table)
     mask = evaluate_expression(expression, env)
-    return table.filter(pa.array(mask))
+    logger.debug("Filter mask length %d", len(mask))
+    result = table.filter(pa.array(mask))
+    logger.debug("Result has %d rows", result.num_rows)
+    return result
 
 
 __all__ = ["filter"]

--- a/barrow/operations/groupby.py
+++ b/barrow/operations/groupby.py
@@ -2,16 +2,23 @@
 
 from __future__ import annotations
 
+import logging
 import pyarrow as pa
+
+
+logger = logging.getLogger(__name__)
 
 
 def groupby(table: pa.Table, keys: str | list[str]) -> pa.Table:
     """Return ``table`` tagged with grouping metadata for ``keys``."""
     if isinstance(keys, str):
         keys = [keys]
+    logger.debug("Grouping with keys %s", keys)
     metadata = dict(table.schema.metadata or {})
     metadata[b"grouped_by"] = ",".join(keys).encode()
-    return table.replace_schema_metadata(metadata)
+    result = table.replace_schema_metadata(metadata)
+    logger.debug("Grouping metadata set to %s", metadata[b"grouped_by"])
+    return result
 
 
 __all__ = ["groupby"]

--- a/barrow/operations/select.py
+++ b/barrow/operations/select.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import pyarrow as pa
+
+
+logger = logging.getLogger(__name__)
 
 
 def select(table: pa.Table, columns: str | list[str] | tuple[str, ...]) -> pa.Table:
@@ -19,7 +23,10 @@ def select(table: pa.Table, columns: str | list[str] | tuple[str, ...]) -> pa.Ta
         cols = [columns]
     else:
         cols = list(columns)
-    return table.select(cols)
+    logger.debug("Selecting columns %s", cols)
+    result = table.select(cols)
+    logger.debug("Selected %d columns", result.num_columns)
+    return result
 
 
 __all__ = ["select"]

--- a/barrow/operations/summary.py
+++ b/barrow/operations/summary.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+import logging
 import pyarrow as pa
 
 from ..errors import BarrowError
+
+
+logger = logging.getLogger(__name__)
 
 
 def summary(
@@ -15,14 +19,21 @@ def summary(
     """Aggregate ``table`` according to ``aggregations`` using grouping metadata."""
     metadata = table.schema.metadata or {}
     grouped_by = metadata.get(b"grouped_by")
+    logger.debug("Grouping metadata: %s", grouped_by)
     if not grouped_by:
         raise BarrowError("summary requires grouping metadata")
     keys = grouped_by.decode().split(",") if grouped_by else []
     if aggregations is None:
         aggregations = {}
     aggregations = {**aggregations, **kwargs}
+    logger.debug("Summarizing with aggregations %s", aggregations)
     pairs = list(aggregations.items())
     result = table.group_by(keys).aggregate(pairs)
+    logger.debug(
+        "Summary result has %d rows and %d columns",
+        result.num_rows,
+        result.num_columns,
+    )
     return result.replace_schema_metadata(metadata)
 
 

--- a/barrow/operations/ungroup.py
+++ b/barrow/operations/ungroup.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 import pyarrow as pa
+
+
+logger = logging.getLogger(__name__)
 
 
 def ungroup(table: pa.Table) -> pa.Table:
     """Return ``table`` without grouping metadata."""
+    logger.debug("Ungrouping table")
     metadata = dict(table.schema.metadata or {})
-    metadata.pop(b"grouped_by", None)
+    removed = metadata.pop(b"grouped_by", None)
+    logger.debug("Removed grouping metadata: %s", removed)
     return table.replace_schema_metadata(metadata or None)
 
 

--- a/tests/operations/test_filter.py
+++ b/tests/operations/test_filter.py
@@ -1,26 +1,35 @@
+import logging
 import pytest
 
 from barrow.expr import parse
 from barrow.operations import filter as filter_rows
 
 
-def test_filter_rows(sample_table):
-    result = filter_rows(sample_table, parse("a > 1"))
+def test_filter_rows(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        result = filter_rows(sample_table, parse("a > 1"))
     assert result["a"].to_pylist() == [2, 3]
+    assert "Filtering with expression" in caplog.text
 
 
-def test_filter_invalid_expression(sample_table):
-    with pytest.raises(NameError):
-        filter_rows(sample_table, parse("c > 1"))
+def test_filter_invalid_expression(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(NameError):
+            filter_rows(sample_table, parse("c > 1"))
+    assert "Filtering with expression" in caplog.text
 
 
-def test_filter_numpy_function(sample_table):
-    result = filter_rows(sample_table, parse("sqrt(a) > 1"))
+def test_filter_numpy_function(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        result = filter_rows(sample_table, parse("sqrt(a) > 1"))
     assert result["a"].to_pylist() == [2, 3]
+    assert "Filtering with expression" in caplog.text
 
 
-def test_filter_unknown_function(sample_table):
+def test_filter_unknown_function(sample_table, caplog):
     expr = parse("nosuch(a)")
-    with pytest.raises(NameError):
-        filter_rows(sample_table, expr)
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(NameError):
+            filter_rows(sample_table, expr)
+    assert "Filtering with expression" in caplog.text
 

--- a/tests/operations/test_groupby_summary.py
+++ b/tests/operations/test_groupby_summary.py
@@ -1,24 +1,34 @@
+import logging
 import pyarrow as pa
 import pytest
 
 from barrow.operations import groupby, summary
 
 
-def test_groupby_summary(parquet_table):
-    gb = groupby(parquet_table.select(["grp", "a"]), "grp")
-    result = summary(gb, {"a": "sum"})
+def test_groupby_summary(parquet_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        gb = groupby(parquet_table.select(["grp", "a"]), "grp")
+        result = summary(gb, {"a": "sum"})
     out = dict(zip(result["grp"].to_pylist(), result["a_sum"].to_pylist()))
     assert out == {"x": 3, "y": 3}
+    assert "Grouping with keys ['grp']" in caplog.text
+    assert "Summarizing with aggregations {'a': 'sum'}" in caplog.text
 
 
-def test_groupby_invalid_key(sample_table):
-    gb = groupby(sample_table, "missing")
-    with pytest.raises(pa.ArrowInvalid):
-        summary(gb, {"a": "sum"})
+def test_groupby_invalid_key(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        gb = groupby(sample_table, "missing")
+        with pytest.raises(pa.ArrowInvalid):
+            summary(gb, {"a": "sum"})
+    assert "Grouping with keys ['missing']" in caplog.text
+    assert "Summarizing with aggregations {'a': 'sum'}" in caplog.text
 
 
-def test_summary_invalid_aggregation(sample_table):
-    gb = groupby(sample_table.select(["grp", "a"]), "grp")
-    with pytest.raises(pa.ArrowKeyError):
-        summary(gb, {"a": "nonesuch"})
+def test_summary_invalid_aggregation(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        gb = groupby(sample_table.select(["grp", "a"]), "grp")
+        with pytest.raises(pa.ArrowKeyError):
+            summary(gb, {"a": "nonesuch"})
+    assert "Grouping with keys ['grp']" in caplog.text
+    assert "Summarizing with aggregations {'a': 'nonesuch'}" in caplog.text
 

--- a/tests/operations/test_mutate.py
+++ b/tests/operations/test_mutate.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import pytest
 
@@ -5,26 +6,34 @@ from barrow.expr import parse
 from barrow.operations import mutate
 
 
-def test_mutate_columns(sample_table):
-    result = mutate(sample_table, c=parse("a + b"), b=parse("b * 2"))
+def test_mutate_columns(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        result = mutate(sample_table, c=parse("a + b"), b=parse("b * 2"))
     assert result.column_names == ["a", "b", "grp", "c"]
     assert result["b"].to_pylist() == [8, 10, 12]
     assert result["c"].to_pylist() == [5, 7, 9]
+    assert "Mutating with expressions" in caplog.text
 
 
-def test_mutate_invalid_expression(sample_table):
-    with pytest.raises(NameError):
-        mutate(sample_table, d=parse("unknown + 1"))
+def test_mutate_invalid_expression(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(NameError):
+            mutate(sample_table, d=parse("unknown + 1"))
+    assert "Evaluating expression for column 'd'" in caplog.text
 
 
-def test_mutate_numpy_function(sample_table):
-    result = mutate(sample_table, d=parse("sqrt(a) + b"))
+def test_mutate_numpy_function(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        result = mutate(sample_table, d=parse("sqrt(a) + b"))
     expected = [np.sqrt(1) + 4, np.sqrt(2) + 5, np.sqrt(3) + 6]
     assert result["d"].to_pylist() == pytest.approx(expected)
+    assert "Evaluating expression for column 'd'" in caplog.text
 
 
-def test_mutate_unknown_function(sample_table):
+def test_mutate_unknown_function(sample_table, caplog):
     expr = parse("nosuch(a)")
-    with pytest.raises(NameError):
-        mutate(sample_table, d=expr)
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(NameError):
+            mutate(sample_table, d=expr)
+    assert "Evaluating expression for column 'd'" in caplog.text
 

--- a/tests/operations/test_select.py
+++ b/tests/operations/test_select.py
@@ -1,14 +1,19 @@
+import logging
 import pytest
 
 from barrow.operations import select
 
 
-def test_select_columns(sample_table):
-    result = select(sample_table, ["a", "grp"])
+def test_select_columns(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        result = select(sample_table, ["a", "grp"])
     assert result.column_names == ["a", "grp"]
+    assert "Selecting columns ['a', 'grp']" in caplog.text
 
 
-def test_select_missing_column(sample_table):
-    with pytest.raises(KeyError):
-        select(sample_table, ["a", "missing"])
+def test_select_missing_column(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(KeyError):
+            select(sample_table, ["a", "missing"])
+    assert "Selecting columns ['a', 'missing']" in caplog.text
 

--- a/tests/operations/test_ungroup.py
+++ b/tests/operations/test_ungroup.py
@@ -1,9 +1,13 @@
+import logging
+
 from barrow.operations import groupby, ungroup
 
 
-def test_ungroup_removes_metadata(sample_table):
-    gb = groupby(sample_table, "grp")
-    assert (gb.schema.metadata or {}).get(b"grouped_by") == b"grp"
-    result = ungroup(gb)
+def test_ungroup_removes_metadata(sample_table, caplog):
+    with caplog.at_level(logging.DEBUG):
+        gb = groupby(sample_table, "grp")
+        assert (gb.schema.metadata or {}).get(b"grouped_by") == b"grp"
+        result = ungroup(gb)
     assert (result.schema.metadata or {}).get(b"grouped_by") is None
+    assert "Ungrouping table" in caplog.text
 


### PR DESCRIPTION
## Summary
- integrate debug logging into select, filter, mutate, groupby, summary and ungroup operations
- extend operation tests to assert logging output using caplog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beec7e98ec832a808266d97b2d8eba