### PR TITLE
test: parametrize select and filter operation tests

### DIFF
--- a/tests/operations/test_filter.py
+++ b/tests/operations/test_filter.py
@@ -5,31 +5,37 @@ from barrow.expr import parse
 from barrow.operations import filter as filter_rows
 
 
-def test_filter_rows(sample_table, caplog):
+@pytest.mark.parametrize(
+    "expr_str,expected",
+    [
+        ("a > 1", [2, 3]),
+        ("sqrt(a) > 1", [2, 3]),
+    ],
+)
+def test_filter_rows(sample_table, expr_str, expected, caplog):
+    """Filtering with valid expressions returns expected rows."""
     with caplog.at_level(logging.DEBUG):
-        result = filter_rows(sample_table, parse("a > 1"))
-    assert result["a"].to_pylist() == [2, 3]
-    assert "Filtering with expression" in caplog.text
+        result = filter_rows(sample_table, parse(expr_str))
+    actual = result["a"].to_pylist()
+    assert (
+        actual == expected
+    ), f"Filtering '{expr_str}' returned {actual}, expected {expected}"
+    assert (
+        "Filtering with expression" in caplog.text
+    ), f"Missing log entry for expression '{expr_str}'"
 
 
-def test_filter_invalid_expression(sample_table, caplog):
+@pytest.mark.parametrize("expr_str", ["c > 1", "nosuch(a)"])
+def test_filter_invalid_expression(sample_table, expr_str, caplog):
+    """Invalid expressions raise ``NameError`` mentioning the culprit."""
     with caplog.at_level(logging.DEBUG):
-        with pytest.raises(NameError):
-            filter_rows(sample_table, parse("c > 1"))
-    assert "Filtering with expression" in caplog.text
-
-
-def test_filter_numpy_function(sample_table, caplog):
-    with caplog.at_level(logging.DEBUG):
-        result = filter_rows(sample_table, parse("sqrt(a) > 1"))
-    assert result["a"].to_pylist() == [2, 3]
-    assert "Filtering with expression" in caplog.text
-
-
-def test_filter_unknown_function(sample_table, caplog):
-    expr = parse("nosuch(a)")
-    with caplog.at_level(logging.DEBUG):
-        with pytest.raises(NameError):
-            filter_rows(sample_table, expr)
-    assert "Filtering with expression" in caplog.text
+        with pytest.raises(NameError) as exc_info:
+            filter_rows(sample_table, parse(expr_str))
+    token = expr_str.split("(")[0].split()[0]
+    assert (
+        token in str(exc_info.value)
+    ), f"Error message does not reference '{token}': {exc_info.value}"
+    assert (
+        "Filtering with expression" in caplog.text
+    ), f"Missing log entry for expression '{expr_str}'"
 

--- a/tests/operations/test_select.py
+++ b/tests/operations/test_select.py
@@ -4,16 +4,36 @@ import pytest
 from barrow.operations import select
 
 
-def test_select_columns(sample_table, caplog):
+@pytest.mark.parametrize(
+    "cols,expected",
+    [
+        (["a", "grp"], ["a", "grp"]),
+        (["b"], ["b"]),
+    ],
+)
+def test_select_columns(sample_table, cols, expected, caplog):
+    """Selecting existing columns returns only those columns."""
     with caplog.at_level(logging.DEBUG):
-        result = select(sample_table, ["a", "grp"])
-    assert result.column_names == ["a", "grp"]
-    assert "Selecting columns ['a', 'grp']" in caplog.text
+        result = select(sample_table, cols)
+    assert (
+        result.column_names == expected
+    ), f"Expected columns {expected} but got {result.column_names} for {cols}"
+    assert (
+        f"Selecting columns {cols}" in caplog.text
+    ), f"Missing log entry for selecting {cols}"
 
 
-def test_select_missing_column(sample_table, caplog):
+@pytest.mark.parametrize("cols", [["a", "missing"], ["missing"]])
+def test_select_missing_column(sample_table, cols, caplog):
+    """Selecting missing columns raises a ``KeyError`` mentioning them."""
     with caplog.at_level(logging.DEBUG):
-        with pytest.raises(KeyError):
-            select(sample_table, ["a", "missing"])
-    assert "Selecting columns ['a', 'missing']" in caplog.text
+        with pytest.raises(KeyError) as exc_info:
+            select(sample_table, cols)
+    missing = [c for c in cols if c not in sample_table.column_names]
+    assert all(
+        m in str(exc_info.value) for m in missing
+    ), f"Error message does not mention missing columns {missing}: {exc_info.value}"
+    assert (
+        f"Selecting columns {cols}" in caplog.text
+    ), f"Missing log entry for selecting {cols}"
 


### PR DESCRIPTION
## Summary
- parametrize select tests to cover valid and missing columns
- consolidate filter tests with parametrize for valid/invalid expressions
- add descriptive assertion messages and log checks

## Testing
- `pre-commit run --files tests/operations/test_select.py tests/operations/test_filter.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest tests/operations/test_select.py tests/operations/test_filter.py`

------
https://chatgpt.com/codex/tasks/task_e_68beedba525c832ab5b032a064655645