### PR TITLE
docs: clarify group metadata and formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,18 @@ All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and `-
 ## Examples
 ### Filter then select
 ```bash
-barrow filter "a > 1" --input data.csv | \
-barrow select "b,grp" --output result.csv
+barrow filter "a > 1" --input data.csv --input-format csv | \
+barrow select "b,grp" --output-format parquet --output result.parquet
 ```
 
 ### Mutate → groupby → summary
 ```bash
-barrow mutate "c=a+b" --input data.csv | \
+barrow mutate "c=a+b" --input data.csv --input-format csv | \
 barrow groupby grp | \
-barrow summary "c=sum" --output out.parquet
+barrow summary "c=sum" --output-format parquet --output out.parquet
 ```
+
+Note: Writing grouped data to CSV drops grouping metadata; use Parquet to preserve it.
 
 These pipelines demonstrate reading from `STDIN` and writing to `STDOUT` while combining operations with pipes.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,18 +8,20 @@ Each command reads from `STDIN` or a file and writes to `STDOUT` or a file. Form
 ## Advanced Examples
 ### Join and Aggregate
 ```bash
-barrow join id id --right other.csv --input data.csv | \
+barrow join id id --right other.csv --input data.csv --input-format csv --right-format csv | \
 barrow mutate "total=price*qty" | \
 barrow groupby category | \
 barrow summary "revenue=sum(total)" --output-format parquet --output report.parquet
 ```
 This pipeline joins two datasets on `id`, computes a new column, groups by `category`, and writes aggregated revenue to a Parquet file.
 
+Note: Writing grouped data to CSV drops grouping metadata; use Parquet to preserve it.
+
 ### Streaming Filters and Projections
 ```bash
 barrow filter "score > 80" --input-format csv | \
 barrow select "name,score" | \
-barrow sort "score" --descending
+barrow sort "score" --descending --output-format parquet --output top.parquet
 ```
 Use streaming operations to filter, project, and sort large datasets without loading them entirely into memory.
 


### PR DESCRIPTION
## Summary
- note that CSV output drops grouping metadata
- show explicit input/output formats using Parquet in examples

## Testing
- `pre-commit run --files docs/usage.md README.md` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bef47770a0832a8c79c9dbb417ece9