### PR TITLE
Preserve grouping metadata in CSV

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -130,17 +130,26 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("assignments", help="Comma-separated NAME=EXPR pairs")
     p.set_defaults(func=_cmd_mutate)
 
-    p = subparsers.add_parser("groupby", help="Group rows by columns")
+    p = subparsers.add_parser(
+        "groupby",
+        help="Group rows by columns (CSV adds '# grouped_by' comment)",
+    )
     _add_io_options(p)
     p.add_argument("columns", help="Comma-separated column names")
     p.set_defaults(func=_cmd_groupby)
 
-    p = subparsers.add_parser("summary", help="Aggregate grouped table")
+    p = subparsers.add_parser(
+        "summary",
+        help="Aggregate grouped table (keeps '# grouped_by' comment in CSV)",
+    )
     _add_io_options(p)
     p.add_argument("aggregations", help="Comma-separated COLUMN=AGG pairs")
     p.set_defaults(func=_cmd_summary)
 
-    p = subparsers.add_parser("ungroup", help="Remove grouping metadata")
+    p = subparsers.add_parser(
+        "ungroup",
+        help="Remove grouping metadata (drops '# grouped_by' CSV comment)",
+    )
     _add_io_options(p)
     p.set_defaults(func=_cmd_ungroup)
 

--- a/barrow/io/writer.py
+++ b/barrow/io/writer.py
@@ -36,9 +36,22 @@ def write_table(table: pa.Table, path: str | None, format: str | None) -> None:
         fmt = "csv"
 
     if fmt == "csv":
+        grouped = (
+            table.schema.metadata.get(b"grouped_by")
+            if table.schema.metadata
+            else None
+        )
+        comment = b"# grouped_by: " + grouped + b"\n" if grouped else None
         if path:
-            csv.write_csv(table, path)
+            if comment:
+                with open(path, "wb") as f:
+                    f.write(comment)
+                    csv.write_csv(table, f)
+            else:
+                csv.write_csv(table, path)
         else:
+            if comment:
+                sys.stdout.buffer.write(comment)
             csv.write_csv(table, sys.stdout.buffer)
         return
     if fmt == "parquet":

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,8 +14,8 @@ barrow groupby category | \
 barrow summary "revenue=sum(total)" --output-format parquet --output report.parquet
 ```
 This pipeline joins two datasets on `id`, computes a new column, groups by `category`, and writes aggregated revenue to a Parquet file.
-
-Note: Writing grouped data to CSV drops grouping metadata; use Parquet to preserve it.
+When writing grouped data to CSV, grouping information is stored in a leading
+comment line of the form `# grouped_by: col1,col2` and is restored on read.
 
 ### Streaming Filters and Projections
 ```bash

--- a/tests/io/test_writer_reader_csv.py
+++ b/tests/io/test_writer_reader_csv.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pyarrow as pa
+
+from barrow.io import read_table, write_table
+from barrow.operations import groupby
+
+
+def test_csv_roundtrip_preserves_grouping(tmp_path) -> None:
+    table = pa.table({"a": [1, 2], "b": [3, 4]})
+    grouped = groupby(table, ["a"])
+    path = tmp_path / "out.csv"
+    write_table(grouped, str(path), None)
+    lines = path.read_text().splitlines()
+    assert lines[0] == "# grouped_by: a"
+    result = read_table(str(path), None)
+    assert result.schema.metadata.get(b"grouped_by") == b"a"
+    assert result.to_pylist() == table.to_pylist()


### PR DESCRIPTION
## Summary
- write grouped column information to CSV as a `# grouped_by:` header comment
- read the `# grouped_by:` comment when loading CSV to restore grouping metadata
- document and test the CSV grouping comment convention

## Testing
- `pre-commit run --files barrow/io/writer.py barrow/io/reader.py barrow/cli.py docs/usage.md tests/io/test_writer_reader_csv.py` *(fails: HTTP 403 fetching ruff-pre-commit)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf040e086c832a9a9b84ebf29a1610