### PR TITLE
Default output format inherits input format

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make clean   # remove build artifacts
 ```
 
 ## Usage
-All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and `--output-format` to control I/O. These options support `csv` or `parquet`. When omitted, formats are inferred from file extensions or magic bytes when reading from `STDIN`. Leaving out `--input` makes the command read from `STDIN`; omitting `--output` writes to `STDOUT`.
+All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and `--output-format` to control I/O. These options support `csv` or `parquet`. When omitted, formats are inferred from file extensions or magic bytes when reading from `STDIN`. Leaving out `--input` makes the command read from `STDIN`; omitting `--output` writes to `STDOUT`. If `--output-format` is not given, the command writes using the input format.
 
 ### filter
 `barrow filter EXPRESSION`
@@ -69,12 +69,14 @@ All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and `-
 ## Examples
 ### Filter then select
 ```bash
+# filter outputs CSV by default; select converts to Parquet
 barrow filter "a > 1" --input data.csv --input-format csv | \
 barrow select "b,grp" --output-format parquet --output result.parquet
 ```
 
 ### Mutate → groupby → summary
 ```bash
+# mutate and groupby inherit CSV; summary converts to Parquet
 barrow mutate "c=a+b" --input data.csv --input-format csv | \
 barrow groupby grp | \
 barrow summary "c=sum" --output-format parquet --output out.parquet

--- a/tests/test_cli_io_defaults.py
+++ b/tests/test_cli_io_defaults.py
@@ -1,0 +1,34 @@
+import pyarrow.parquet as pq
+import pytest
+
+from barrow.cli import main
+
+
+def test_filter_inherits_input_format(sample_parquet, tmp_path) -> None:
+    out = tmp_path / "out"
+    rc = main([
+        "filter",
+        "a > 1",
+        "--input",
+        sample_parquet,
+        "--output",
+        str(out),
+    ])
+    assert rc == 0
+    table = pq.read_table(out)
+    assert table.to_pydict()["a"] == [2, 3]
+
+
+@pytest.mark.parametrize(
+    "command, args",
+    [
+        ("select", ["a,b,grp"]),
+        ("mutate", ["c=a+b"]),
+        ("groupby", ["grp"]),
+    ],
+)
+def test_other_commands_inherit_format(command, args, sample_parquet, tmp_path) -> None:
+    out = tmp_path / "out"
+    rc = main([command, *args, "--input", sample_parquet, "--output", str(out)])
+    assert rc == 0
+    pq.read_table(out)


### PR DESCRIPTION
## Summary
- Default CLI output format to match input format when `--output-format` is omitted
- Document inherited output format in command docs and README examples
- Test CLI commands preserve format without explicit `--output-format`

## Testing
- `pre-commit run --files barrow/cli.py README.md tests/test_cli_io_defaults.py` *(fails: HTTP 403 fetching ruff-pre-commit)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf080f5d50832a8e8638d809736e36