### PR TITLE
docs: add filter-mutate-select-groupby-summary example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,22 @@ barrow groupby grp | \
 barrow summary "c=sum" --output-format parquet --output out.parquet
 ```
 
+### Filter → mutate → select → groupby → summary
+```bash
+# filter, mutate, select, groupby, and summarize
+barrow filter "a > 1" --input data.csv --input-format csv | \
+barrow mutate "c=a+b" | \
+barrow select "c,grp" | \
+barrow groupby grp | \
+barrow summary "c=sum"
+```
+
+```csv
+grp,c_sum
+x,7
+y,9
+```
+
 Note: Writing grouped data to CSV drops grouping metadata; use Parquet to preserve it.
 
 These pipelines demonstrate reading from `STDIN` and writing to `STDOUT` while combining operations with pipes.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,6 +25,22 @@ barrow sort "score" --descending --output-format parquet --output top.parquet
 ```
 Use streaming operations to filter, project, and sort large datasets without loading them entirely into memory.
 
+### Filter → mutate → select → groupby → summary
+```bash
+# filter, mutate, select, groupby, and summarize
+barrow filter "a > 1" --input data.csv --input-format csv | \
+barrow mutate "c=a+b" | \
+barrow select "c,grp" | \
+barrow groupby grp | \
+barrow summary "c=sum"
+```
+
+```csv
+grp,c_sum
+x,7
+y,9
+```
+
 ### Inspecting Results
 When working with binary formats like Parquet, append `view` to a pipeline to
 inspect the data in a human-readable form:


### PR DESCRIPTION
## Summary
- add example showing filter → mutate → select → groupby → summary pipeline
- document the same example in advanced usage

## Testing
- `make lint` *(fails: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1fb57ac0832a99111ee7e87b79d5