### PR TITLE
Add CLI manual and update documentation navigation

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,0 +1,76 @@
+# Manual
+
+`barrow` provides subcommands for working with tabular data. Each command can read from `STDIN` or a file and write to `STDOUT` or a file.
+
+## Common I/O options
+
+- `-i`, `--input PATH` – input file. Reads `STDIN` if omitted.
+- `--input-format {csv,parquet}` – format of the input file.
+- `-o`, `--output PATH` – output file. Writes to `STDOUT` if omitted.
+- `--output-format {csv,parquet}` – format of the output. Defaults to the input format and is ignored by `view`.
+
+## filter
+Filter rows using a boolean expression.
+
+```
+barrow filter "score > 80" -i data.csv -o filtered.csv
+```
+
+## select
+Select a comma-separated list of columns.
+
+```
+barrow select "name,score" -i data.csv -o subset.csv
+```
+
+## mutate
+Add or modify columns with `NAME=EXPR` pairs.
+
+```
+barrow mutate "total=price*qty" -i sales.csv -o extended.csv
+```
+
+## groupby
+Group rows by columns.
+
+```
+barrow groupby category -i sales.csv | barrow summary "revenue=sum(total)"
+```
+
+Grouped data keeps track of the grouping so that subsequent operations like `summary` can aggregate correctly.
+
+## summary
+Aggregate a grouped table with `COLUMN=AGG` pairs.
+
+```
+barrow groupby category -i sales.csv | barrow summary "revenue=sum(total)"
+```
+
+## ungroup
+Remove grouping metadata.
+
+```
+barrow groupby category -i data.csv | barrow ungroup
+```
+
+## join
+Join two tables on key columns.
+
+```
+barrow join id id --right other.csv -i left.csv -o joined.csv
+```
+
+Additional options:
+
+- `--right PATH` – right input file.
+- `--right-format {csv,parquet}` – format of the right file.
+- `--join-type {inner,left,right,outer}` – type of join (default `inner`).
+
+## view
+Display a table in CSV format to `STDOUT` for inspection.
+
+```
+barrow view -i data.parquet
+```
+
+`view` accepts `--output-format` for API compatibility but always writes CSV to `STDOUT`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Barrow
 nav:
   - Installation: installation.md
   - Usage: usage.md
+  - Manual: manual.md
 docs_dir: docs
 theme:
   name: material


### PR DESCRIPTION
## Summary
- Document command-line subcommands, shared I/O options, and usage examples in a new `docs/manual.md`.
- Link the manual page in the MkDocs navigation.

## Testing
- `make lint` *(fails: CalledProcessError: git fetch origin --tags, error: RPC failed; HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf27f4a330832a93c4758fa2a9006a