### PR TITLE
Store table format metadata and reuse when writing

### DIFF
--- a/barrow/io/writer.py
+++ b/barrow/io/writer.py
@@ -32,6 +32,10 @@ def write_table(table: pa.Table, path: str | None, format: str | None) -> None:
             fmt = "csv"
         elif ext == ".parquet":
             fmt = "parquet"
+    if fmt is None and table.schema.metadata:
+        fmt_meta = table.schema.metadata.get(b"format")
+        if fmt_meta:
+            fmt = fmt_meta.decode().lower()
     if fmt is None:
         fmt = "csv"
 

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -18,11 +18,13 @@ def test_read_table_infers_format_from_extension(tmp_path: Path) -> None:
     csv_path.write_text(data)
     table = read_table(str(csv_path), None)
     assert table.to_pylist() == [{"a": 1, "b": 2}]
+    assert table.schema.metadata[b"format"] == b"csv"
 
     pq_path = tmp_path / "input.parquet"
     pq.write_table(pa.table({"a": [1]}), pq_path)
     table = read_table(str(pq_path), None)
     assert table.to_pydict() == {"a": [1]}
+    assert table.schema.metadata[b"format"] == b"parquet"
 
 
 def test_read_table_from_stdin_csv(monkeypatch) -> None:
@@ -35,6 +37,7 @@ def test_read_table_from_stdin_csv(monkeypatch) -> None:
     monkeypatch.setattr(sys, "stdin", Dummy(data))
     table = read_table(None, None)
     assert table.to_pylist() == [{"a": 1, "b": 2}]
+    assert table.schema.metadata[b"format"] == b"csv"
 
 
 def test_read_table_from_stdin_parquet(monkeypatch) -> None:
@@ -48,6 +51,7 @@ def test_read_table_from_stdin_parquet(monkeypatch) -> None:
     monkeypatch.setattr(sys, "stdin", Dummy(buf.getvalue()))
     table = read_table(None, None)
     assert table.to_pydict() == {"a": [1]}
+    assert table.schema.metadata[b"format"] == b"parquet"
 
 
 def test_write_table_to_stdout_defaults_csv(capsys) -> None:
@@ -64,6 +68,31 @@ def test_write_table_infers_from_extension(tmp_path: Path) -> None:
 
     write_table(table, str(pq_path), None)
     assert pq.read_table(pq_path).to_pydict() == {"a": [1]}
+
+
+def test_write_table_uses_format_metadata(tmp_path: Path) -> None:
+    pq_path = tmp_path / "input.parquet"
+    pq.write_table(pa.table({"a": [1]}), pq_path)
+    table = read_table(str(pq_path), None)
+    out = tmp_path / "output"
+    write_table(table, str(out), None)
+    assert pq.read_table(out).to_pydict() == {"a": [1]}
+
+
+def test_write_table_to_stdout_uses_format_metadata(monkeypatch, tmp_path: Path) -> None:
+    pq_path = tmp_path / "input.parquet"
+    pq.write_table(pa.table({"a": [1]}), pq_path)
+    table = read_table(str(pq_path), None)
+
+    buf = io.BytesIO()
+
+    class Dummy:
+        def __init__(self, b: io.BytesIO) -> None:
+            self.buffer = b
+
+    monkeypatch.setattr(sys, "stdout", Dummy(buf))
+    write_table(table, None, None)
+    assert buf.getvalue().startswith(b"PAR1")
 
 
 def test_read_table_unsupported_format() -> None:


### PR DESCRIPTION
## Summary
- save detected format in table schema metadata when reading
- reuse table schema format metadata when writing without explicit format
- expand IO tests to cover format metadata behavior

## Testing
- `pre-commit run --files barrow/io/reader.py barrow/io/writer.py tests/io/test_io.py` *(failed: HTTP 403 fetching hook)*
- `pytest tests/io/test_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfe0d52d3c832aab35a0b8402696d3