### PR TITLE
feat: support custom CSV delimiters

### DIFF
--- a/tests/io/test_delimiters.py
+++ b/tests/io/test_delimiters.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+from barrow.io import read_table, write_table
+
+
+def _csv_content(delimiter: str) -> str:
+    return f"a{delimiter}b\n1{delimiter}2\n"
+
+
+@pytest.mark.parametrize("delimiter", [";", "\t"])
+def test_read_table_sniffs_custom_delimiter(tmp_path, delimiter: str) -> None:
+    path = tmp_path / "in.csv"
+    path.write_text(_csv_content(delimiter))
+    table = read_table(str(path), None, None)
+    assert table.to_pydict() == {"a": [1], "b": [2]}
+
+
+@pytest.mark.parametrize("delimiter", [";", "\t"])
+def test_write_table_custom_delimiter(tmp_path, delimiter: str) -> None:
+    table = pa.table({"a": [1], "b": [2]})
+    path = tmp_path / "out.csv"
+    write_table(table, str(path), "csv", delimiter)
+    first_line = path.read_text().splitlines()[0]
+    assert first_line == f'"a"{delimiter}"b"'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from barrow.errors import InvalidExpressionError
 
 
 def test_cli_returns_error_on_exception(monkeypatch, capsys) -> None:
-    def fake_read_table(path, fmt):
+    def fake_read_table(path, fmt, delimiter=None):
         raise InvalidExpressionError("bad format")
 
     monkeypatch.setattr("barrow.cli.read_table", fake_read_table)


### PR DESCRIPTION
## Summary
- allow `read_table` to guess delimiters with `csv.Sniffer`
- support custom delimiters in `write_table`
- expose `--delimiter` CLI option
- test semicolon and tab delimiters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe1d1327c832a89318a6e97b9dd0e