### PR TITLE
Add Feather-based tmp piping

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -35,7 +35,7 @@ def _add_io_options(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument("--input", "-i", help="Input file. Reads STDIN if omitted.")
     parser.add_argument(
-        "--input-format", choices=["csv", "parquet"], help="Input format"
+        "--input-format", choices=["csv", "parquet", "feather"], help="Input format"
     )
     parser.add_argument(
         "--output",
@@ -43,14 +43,25 @@ def _add_io_options(parser: argparse.ArgumentParser) -> None:
         help="Output file. Writes to STDOUT if omitted.",
     )
     parser.add_argument(
-        "--output-format", choices=["csv", "parquet"], help="Output format"
+        "--output-format", choices=["csv", "parquet", "feather"], help="Output format"
     )
     parser.add_argument(
         "--delimiter",
         help="Field delimiter for CSV input and output",
     )
+    parser.add_argument(
+        "--tmp",
+        "-t",
+        action="store_true",
+        help="Use Feather for intermediate pipe format",
+    )
 
     def _set_io_defaults(args: argparse.Namespace) -> None:
+        if args.tmp:
+            if args.output_format is None:
+                args.output_format = "feather"
+            if args.input is None and args.input_format is None:
+                args.input_format = "feather"
         if args.output_format is None:
             if args.input_format is not None:
                 args.output_format = args.input_format
@@ -60,6 +71,8 @@ def _add_io_options(parser: argparse.ArgumentParser) -> None:
                     args.output_format = "csv"
                 elif ext == ".parquet":
                     args.output_format = "parquet"
+                elif ext == ".feather":
+                    args.output_format = "feather"
 
     parser.set_defaults(_set_io_defaults=_set_io_defaults)
 

--- a/barrow/io/writer.py
+++ b/barrow/io/writer.py
@@ -6,6 +6,7 @@ import sys
 import pyarrow as pa
 import pyarrow.csv as csv
 import pyarrow.parquet as pq
+import pyarrow.feather as feather
 
 from ..errors import UnsupportedFormatError
 
@@ -25,9 +26,9 @@ def write_table(
     path:
         Destination path. When ``None`` the table is written to ``STDOUT``.
     format:
-        The file format. Supported values are ``"csv"`` and ``"parquet"``.
-        If ``None``, the format is inferred from ``path`` when available and
-        otherwise defaults to CSV.
+        The file format. Supported values are ``"csv"``, ``"parquet"`` and
+        ``"feather"``. If ``None``, the format is inferred from ``path`` when
+        available and otherwise defaults to CSV.
     output_delimiter:
         Field delimiter for CSV outputs. When ``None`` a comma is used.
     """
@@ -39,6 +40,8 @@ def write_table(
             fmt = "csv"
         elif ext == ".parquet":
             fmt = "parquet"
+        elif ext == ".feather":
+            fmt = "feather"
     if fmt is None and table.schema.metadata:
         fmt_meta = table.schema.metadata.get(b"format")
         if fmt_meta:
@@ -70,6 +73,12 @@ def write_table(
             pq.write_table(table, path)
         else:
             pq.write_table(table, sys.stdout.buffer)
+        return
+    if fmt == "feather":
+        if path:
+            feather.write_feather(table, path)
+        else:
+            feather.write_feather(table, sys.stdout.buffer)
         return
     raise UnsupportedFormatError(f"Unsupported format: {format}")
 

--- a/tests/io/test_tmp_pipeline_feather.py
+++ b/tests/io/test_tmp_pipeline_feather.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pyarrow.feather as feather
+
+
+def test_tmp_pipeline_feather(sample_csv, tmp_path) -> None:
+    dst = tmp_path / "out.feather"
+
+    cmd_filter = [
+        sys.executable,
+        "-m",
+        "barrow.cli",
+        "filter",
+        "a > 1",
+        "--input",
+        sample_csv,
+        "-t",
+    ]
+    cmd_select = [
+        sys.executable,
+        "-m",
+        "barrow.cli",
+        "select",
+        "b,grp",
+        "-t",
+        "--output",
+        str(dst),
+    ]
+    p1 = subprocess.Popen(cmd_filter, stdout=subprocess.PIPE)
+    p2 = subprocess.Popen(cmd_select, stdin=p1.stdout)
+    assert p1.stdout is not None
+    p1.stdout.close()
+    p2.communicate()
+    assert p2.returncode == 0
+
+    table = feather.read_table(dst)
+    assert table.column_names == ["b", "grp"]
+    assert table.to_pydict() == {"b": [5, 6], "grp": ["x", "y"]}
+


### PR DESCRIPTION
## Summary
- add `--tmp`/`-t` flag defaulting to Feather for piped IO
- support Feather format in reader and writer
- test tmp flag pipelines using Feather

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe442cbc4832aa74de088420b3451