### PR TITLE
Add CLI output format flags and output delimiter override

### DIFF
--- a/tests/io/test_cli_output_formats.py
+++ b/tests/io/test_cli_output_formats.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pyarrow.csv as csv
+import pyarrow.feather as feather
+import pyarrow.parquet as pq
+import pytest
+
+from barrow.cli import main
+
+
+@pytest.mark.parametrize(
+    "flag, ext, reader",
+    [
+        ("--csv", ".csv", csv.read_csv),
+        ("--parquet", ".parquet", pq.read_table),
+        ("--feather", ".feather", feather.read_table),
+    ],
+)
+def test_cli_output_format_flags(tmp_path, sample_csv, sample_table, flag, ext, reader) -> None:
+    dst = tmp_path / f"out{ext}"
+    rc = main([
+        "select",
+        "a,b,grp",
+        "--input",
+        sample_csv,
+        flag,
+        "--output",
+        str(dst),
+    ])
+    assert rc == 0
+    table = reader(dst)
+    assert table.to_pydict() == sample_table.to_pydict()
+
+
+def test_cli_csv_out_delimiter(tmp_path, sample_csv) -> None:
+    dst = tmp_path / "out.csv"
+    rc = main([
+        "select",
+        "a,b",
+        "--input",
+        sample_csv,
+        "--csv",
+        "--csv-out-delimiter",
+        ";",
+        "--output",
+        str(dst),
+    ])
+    assert rc == 0
+    first_line = dst.read_text().splitlines()[0]
+    assert first_line == '"a";"b"'


### PR DESCRIPTION
## Summary
- expose `--csv`, `--parquet`, and `--feather` flags to choose output format
- allow overriding CSV output delimiter via `--csv-out-delimiter`
- test CLI output format flags and custom CSV separator

## Testing
- `pre-commit run --files barrow/cli.py tests/io/test_cli_output_formats.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfe558e4e0832a91f3e3b89b352451