### PR TITLE
Add ORC format support

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -35,7 +35,7 @@ def _add_io_options(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument("--input", "-i", help="Input file. Reads STDIN if omitted.")
     parser.add_argument(
-        "--input-format", choices=["csv", "parquet", "feather"], help="Input format"
+        "--input-format", choices=["csv", "parquet", "feather", "orc"], help="Input format"
     )
     parser.add_argument(
         "--output",
@@ -45,7 +45,7 @@ def _add_io_options(parser: argparse.ArgumentParser) -> None:
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--output-format",
-        choices=["csv", "parquet", "feather"],
+        choices=["csv", "parquet", "feather", "orc"],
         help="Output format",
     )
     group.add_argument(
@@ -68,6 +68,13 @@ def _add_io_options(parser: argparse.ArgumentParser) -> None:
         action="store_const",
         const="feather",
         help="Write output in Feather format",
+    )
+    group.add_argument(
+        "--orc",
+        dest="output_format",
+        action="store_const",
+        const="orc",
+        help="Write output in ORC format",
     )
     parser.add_argument(
         "--delimiter",
@@ -102,6 +109,8 @@ def _add_io_options(parser: argparse.ArgumentParser) -> None:
                     args.output_format = "parquet"
                 elif ext == ".feather":
                     args.output_format = "feather"
+                elif ext == ".orc":
+                    args.output_format = "orc"
 
     parser.set_defaults(_set_io_defaults=_set_io_defaults)
 
@@ -368,7 +377,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("right_on", help="Join key in the right table")
     p.add_argument("--right", required=True, help="Right input file")
     p.add_argument(
-        "--right-format", choices=["csv", "parquet"], help="Right file format"
+        "--right-format", choices=["csv", "parquet", "orc"], help="Right file format"
     )
     p.add_argument(
         "--join-type",
@@ -388,10 +397,10 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawTextHelpFormatter,
     )
     p.add_argument("--input", "-i", help="Input file. Reads STDIN if omitted.")
-    p.add_argument("--input-format", choices=["csv", "parquet"], help="Input format")
+    p.add_argument("--input-format", choices=["csv", "parquet", "orc"], help="Input format")
     p.add_argument(
         "--output-format",
-        choices=["csv", "parquet"],
+        choices=["csv", "parquet", "orc"],
         help="Output format (ignored)",
     )
     p.add_argument(

--- a/barrow/io/writer.py
+++ b/barrow/io/writer.py
@@ -7,6 +7,7 @@ import pyarrow as pa
 import pyarrow.csv as csv
 import pyarrow.parquet as pq
 import pyarrow.feather as feather
+import pyarrow.orc as orc
 
 from ..errors import UnsupportedFormatError
 
@@ -26,9 +27,9 @@ def write_table(
     path:
         Destination path. When ``None`` the table is written to ``STDOUT``.
     format:
-        The file format. Supported values are ``"csv"``, ``"parquet"`` and
-        ``"feather"``. If ``None``, the format is inferred from ``path`` when
-        available and otherwise defaults to CSV.
+        The file format. Supported values are ``"csv"``, ``"parquet``,
+        ``"feather"`` and ``"orc"``. If ``None``, the format is inferred from
+        ``path`` when available and otherwise defaults to CSV.
     output_delimiter:
         Field delimiter for CSV outputs. When ``None`` a comma is used.
     """
@@ -42,6 +43,8 @@ def write_table(
             fmt = "parquet"
         elif ext == ".feather":
             fmt = "feather"
+        elif ext == ".orc":
+            fmt = "orc"
     if fmt is None and table.schema.metadata:
         fmt_meta = table.schema.metadata.get(b"format")
         if fmt_meta:
@@ -79,6 +82,12 @@ def write_table(
             feather.write_feather(table, path)
         else:
             feather.write_feather(table, sys.stdout.buffer)
+        return
+    if fmt == "orc":
+        if path:
+            orc.write_table(table, path)
+        else:
+            orc.write_table(table, sys.stdout.buffer)
         return
     raise UnsupportedFormatError(f"Unsupported format: {format}")
 

--- a/tests/cli/test_view.py
+++ b/tests/cli/test_view.py
@@ -3,18 +3,27 @@ import subprocess
 import sys
 
 import pyarrow.csv as csv
+import pytest
 
 
-def test_view_reads_parquet_and_writes_csv(sample_parquet, sample_table) -> None:
+@pytest.mark.parametrize(
+    "fixture, fmt",
+    [
+        ("sample_parquet", "parquet"),
+        ("sample_orc", "orc"),
+    ],
+)
+def test_view_reads_binary_and_writes_csv(fixture, fmt, request, sample_table) -> None:
+    src = request.getfixturevalue(fixture)
     cmd = [
         sys.executable,
         "-m",
         "barrow.cli",
         "view",
         "--input",
-        sample_parquet,
+        src,
         "--output-format",
-        "parquet",
+        fmt,
     ]
     result = subprocess.run(cmd, capture_output=True)
     assert result.returncode == 0, result.stderr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pyarrow as pa
 import pyarrow.csv as csv
 import pyarrow.parquet as pq
+import pyarrow.orc as orc
 import pytest
 
 
@@ -27,6 +28,20 @@ def sample_parquet(tmp_path, sample_table) -> str:
 
 
 @pytest.fixture
+def sample_orc(tmp_path, sample_table) -> str:
+    """Path to an ORC file with ``sample_table`` data."""
+    path = tmp_path / "data.orc"
+    orc.write_table(sample_table, path)
+    return str(path)
+
+
+@pytest.fixture
 def parquet_table(sample_parquet) -> pa.Table:
     """Table loaded from the ``sample_parquet`` fixture."""
     return pq.read_table(sample_parquet)
+
+
+@pytest.fixture
+def orc_table(sample_orc) -> pa.Table:
+    """Table loaded from the ``sample_orc`` fixture."""
+    return orc.read_table(sample_orc)

--- a/tests/io/test_cli_output_formats.py
+++ b/tests/io/test_cli_output_formats.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pyarrow.csv as csv
 import pyarrow.feather as feather
 import pyarrow.parquet as pq
+import pyarrow.orc as orc
 import pytest
 
 from barrow.cli import main
@@ -14,6 +15,7 @@ from barrow.cli import main
         ("--csv", ".csv", csv.read_csv),
         ("--parquet", ".parquet", pq.read_table),
         ("--feather", ".feather", feather.read_table),
+        ("--orc", ".orc", orc.read_table),
     ],
 )
 def test_cli_output_format_flags(tmp_path, sample_csv, sample_table, flag, ext, reader) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import sys
 import pyarrow as pa
 import pyarrow.csv as csv
 import pyarrow.parquet as pq
+import pyarrow.orc as orc
 import pytest
 
 from barrow.cli import main
@@ -128,6 +129,7 @@ def test_groupby_summary_pipeline(sample_csv, tmp_path) -> None:
     [
         pytest.param("sample_csv", csv.read_csv, ".csv", id="csv"),
         pytest.param("sample_parquet", pq.read_table, ".parquet", id="parquet"),
+        pytest.param("sample_orc", orc.read_table, ".orc", id="orc"),
     ],
 )
 def test_select_handles_various_formats(

--- a/tests/test_cli_io_defaults.py
+++ b/tests/test_cli_io_defaults.py
@@ -1,23 +1,32 @@
 import pyarrow.parquet as pq
+import pyarrow.orc as orc
 import pytest
 
 from barrow.cli import main
 
 
-def test_filter_inherits_input_format(sample_parquet, tmp_path) -> None:
+@pytest.mark.parametrize(
+    "src_fixture, reader",
+    [
+        ("sample_parquet", pq.read_table),
+        ("sample_orc", orc.read_table),
+    ],
+)
+def test_filter_inherits_input_format(src_fixture, reader, request, tmp_path) -> None:
+    sample = request.getfixturevalue(src_fixture)
     out = tmp_path / "out"
     rc = main(
         [
             "filter",
             "a > 1",
             "--input",
-            sample_parquet,
+            sample,
             "--output",
             str(out),
         ]
     )
     assert rc == 0
-    table = pq.read_table(out)
+    table = reader(out)
     assert table.to_pydict()["a"] == [2, 3]
 
 
@@ -29,8 +38,16 @@ def test_filter_inherits_input_format(sample_parquet, tmp_path) -> None:
         ("groupby", ["grp"]),
     ],
 )
-def test_other_commands_inherit_format(command, args, sample_parquet, tmp_path) -> None:
+@pytest.mark.parametrize(
+    "src_fixture, reader",
+    [
+        ("sample_parquet", pq.read_table),
+        ("sample_orc", orc.read_table),
+    ],
+)
+def test_other_commands_inherit_format(command, args, src_fixture, reader, request, tmp_path) -> None:
+    sample = request.getfixturevalue(src_fixture)
     out = tmp_path / "out"
-    rc = main([command, *args, "--input", sample_parquet, "--output", str(out)])
+    rc = main([command, *args, "--input", sample, "--output", str(out)])
     assert rc == 0
-    pq.read_table(out)
+    reader(out)


### PR DESCRIPTION
## Summary
- support ORC files in reader and writer
- add `--orc` CLI flag and allow ORC in format choices
- test ORC round-trips through files and STDIO

## Testing
- `python -m pre_commit run --files barrow/io/reader.py barrow/io/writer.py barrow/cli.py tests/io/test_io.py tests/io/test_cli_output_formats.py tests/cli/test_view.py tests/conftest.py tests/test_cli.py tests/test_cli_io_defaults.py` *(failed: error: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403)*
- `pytest`
- `pytest tests/io/test_io.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfe697daf4832ab544765035ba27e0