### PR TITLE
docs: document supported formats and I/O flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # barrow
 A Bash tool for data manipulation using tabular formats, based on Apache Arrow.
 It supports common data operations like select, filter, mutate, groupby, summary, ungroup, and join.
-Commands read from files or `STDIN` and write to files or `STDOUT` in CSV or Parquet format.
+Commands read from files or `STDIN` and write to files or `STDOUT` in CSV, Parquet,
+Feather, or ORC format.
 
 ## Installation
 ```bash
@@ -36,7 +37,16 @@ make clean   # remove build artifacts
 ```
 
 ## Usage
-All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and `--output-format` to control I/O. These options support `csv` or `parquet`. When omitted, formats are inferred from file extensions or magic bytes when reading from `STDIN`. Leaving out `--input` makes the command read from `STDIN`; omitting `--output` writes to `STDOUT`. If `--output-format` is not given, the command writes using the input format.
+All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and
+`--output-format` to control I/O. These options support `csv`, `parquet`,
+`feather`, or `orc`. Convenience flags `--csv`, `--parquet`, `--feather`, and
+`--orc` set the output format directly. Use `--delimiter` to specify the field
+delimiter for CSV input and output, or `--csv-out-delimiter` to choose a
+different delimiter for CSV output. `--tmp` writes Feather to pipes for faster
+intermediate processing. When omitted, formats are inferred from file extensions
+or magic bytes when reading from `STDIN`. Leaving out `--input` makes the
+command read from `STDIN`; omitting `--output` writes to `STDOUT`. If
+`--output-format` is not given, the command writes using the input format.
 
 ### filter
 `barrow filter EXPRESSION`
@@ -69,17 +79,24 @@ All subcommands accept `--input`/`-i`, `--input-format`, `--output`/`-o`, and `-
 ## Examples
 ### Filter then select
 ```bash
-# filter outputs CSV by default; select converts to Parquet
-barrow filter "a > 1" --input data.csv --input-format csv | \
-barrow select "b,grp" --output-format parquet --output result.parquet
+# filter outputs CSV by default; select uses the --parquet shortcut
+barrow filter "a > 1" --input data.csv | \
+barrow select "b,grp" --parquet --output result.parquet
 ```
 
 ### Mutate → groupby → summary
 ```bash
-# mutate and groupby inherit CSV; summary converts to Parquet
-barrow mutate "c=a+b" --input data.csv --input-format csv | \
-barrow groupby grp | \
-barrow summary "c=sum" --output-format parquet --output out.parquet
+# mutate and groupby use Feather pipes with --tmp; summary outputs Parquet
+barrow mutate "c=a+b" --input data.csv --tmp | \
+barrow groupby grp --tmp | \
+barrow summary "c=sum" --parquet --output out.parquet
+```
+
+### Custom delimiters
+```bash
+# read tab-separated input and write semicolon-separated output
+barrow select "a,b" --input data.tsv --delimiter '\t' --csv-out-delimiter ';' \
+  --output result.csv
 ```
 
 ### Filter → mutate → select → groupby → summary


### PR DESCRIPTION
## Summary
- list CSV, Parquet, Feather, and ORC as supported formats
- document `--csv`, `--parquet`, `--feather`, `--orc`, `--delimiter`, `--csv-out-delimiter`, and `--tmp`
- expand examples to show format flags, temporary Feather pipes, and custom delimiters

## Testing
- `pre-commit run --files README.md` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfe9fab06c832a8847a1ff9fe0c90b