### PR TITLE
docs: document additional formats and options

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -5,9 +5,13 @@
 ## Common I/O options
 
 - `-i`, `--input PATH` – input file. Reads `STDIN` if omitted.
-- `--input-format {csv,parquet}` – format of the input file.
+- `--input-format {csv,parquet,feather,orc}` – format of the input file.
 - `-o`, `--output PATH` – output file. Writes to `STDOUT` if omitted.
-- `--output-format {csv,parquet}` – format of the output. Defaults to the input format and is ignored by `view`.
+- `--output-format {csv,parquet,feather,orc}` – format of the output. Defaults to the input format and is ignored by `view`.
+- `--csv`, `--parquet`, `--feather`, `--orc` – shortcut flags to set the output format.
+- `--delimiter CHAR` – field delimiter for CSV input; also used for output unless `--csv-out-delimiter` is given.
+- `--csv-out-delimiter CHAR` – field delimiter for CSV output.
+- `--tmp` – write intermediate results to Feather when using pipes for faster processing.
 
 ## filter
 Filter rows using a boolean expression.
@@ -63,7 +67,7 @@ barrow join id id --right other.csv -i left.csv -o joined.csv
 Additional options:
 
 - `--right PATH` – right input file.
-- `--right-format {csv,parquet}` – format of the right file.
+- `--right-format {csv,parquet,feather,orc}` – format of the right file.
 - `--join-type {inner,left,right,outer}` – type of join (default `inner`).
 
 ## view


### PR DESCRIPTION
## Summary
- document Feather and ORC as supported input/output formats
- describe delimiter, csv-out-delimiter, tmp, and shortcut format flags
- mention extended right-format options for join

## Testing
- `pre-commit run --files docs/manual.md` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags') return code: 128)*

------
https://chatgpt.com/codex/tasks/task_e_68bfeab43ae4832aa4fb9cd666600f07