### PR TITLE
docs: record new formats and flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,9 @@
 # Changelog
+
+## Unreleased
+
+- 2025-09-09: Support custom CSV delimiters (`7c842e3`)
+- 2025-09-09: Add Feather format support (`f912662`)
+- 2025-09-09: Introduce `--tmp` flag for temporary Feather files (`f912662`)
+- 2025-09-09: Introduce quick output format flags (`1952a4e`)
+- 2025-09-09: Add ORC format support (`5241f6b`)


### PR DESCRIPTION
## Summary
- document support for custom CSV delimiters
- note Feather format and `--tmp` flag
- record quick output format flags and ORC support

## Testing
- `pre-commit run --files CHANGELOG.md` *(fails: HTTP 403 from git fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68bfec165e8c832a84d95e72e2e232d3