### PR TITLE
feat: support feather right files in join

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -379,7 +379,9 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("right_on", help="Join key in the right table")
     p.add_argument("--right", required=True, help="Right input file")
     p.add_argument(
-        "--right-format", choices=["csv", "parquet", "orc"], help="Right file format"
+        "--right-format",
+        choices=["csv", "parquet", "feather", "orc"],
+        help="Right file format",
     )
     p.add_argument(
         "--join-type",


### PR DESCRIPTION
## Summary
- allow specifying `feather` for `--right-format` in `join`
- test joining with a feather-formatted right table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bfed05d1c4832aad8672428ed9640b