### PR TITLE
Fix benchmark errors in etl_pipe and analytics_pipe

### DIFF
--- a/barrow/cli.py
+++ b/barrow/cli.py
@@ -92,8 +92,6 @@ def _add_io_options(parser: argparse.ArgumentParser) -> None:
         if args.tmp:
             if args.output_format is None:
                 args.output_format = "feather"
-            if args.input is None and args.input_format is None:
-                args.input_format = "feather"
         if args.output_format is None:
             if args.input_format is not None:
                 args.output_format = args.input_format

--- a/scripts/analyze_bench.py
+++ b/scripts/analyze_bench.py
@@ -183,7 +183,7 @@ def run_analysis(df: pd.DataFrame, has_resources: bool) -> dict:
                     {
                         "dataset": ds,
                         "mean_s": round(ds_data["seconds"].mean(), 4),
-                        "rows": int(ds_data["rows"].iloc[0]),
+                        "rows": int(ds_data["rows"].iloc[0]) if pd.notna(ds_data["rows"].iloc[0]) else 0,
                     }
                 )
         if len(sizes) >= 2:

--- a/scripts/analyze_bench.py
+++ b/scripts/analyze_bench.py
@@ -183,7 +183,11 @@ def run_analysis(df: pd.DataFrame, has_resources: bool) -> dict:
                     {
                         "dataset": ds,
                         "mean_s": round(ds_data["seconds"].mean(), 4),
-                        "rows": int(ds_data["rows"].iloc[0]) if pd.notna(ds_data["rows"].iloc[0]) else 0,
+                        "rows": (
+                            int(ds_data["rows"].iloc[0])
+                            if pd.notna(ds_data["rows"].iloc[0])
+                            else 0
+                        ),
                     }
                 )
         if len(sizes) >= 2:

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -417,8 +417,6 @@ else:
     cpu_pct = int(cpu_total / elapsed * 100) if elapsed > 0 else 0
     exit_code = proc.returncode
 
-if exit_code != 0:
-    raise subprocess.CalledProcessError(exit_code, command)
 print(f"{elapsed:.6f}\t{peak_rss_kb}\t{cpu_user_s:.6f}\t{cpu_sys_s:.6f}\t{cpu_pct}\t{exit_code}")
 PY
 )"
@@ -614,8 +612,17 @@ for row in rows:
     key = (row["dataset"], row["rows"], row["benchmark"], row["variant"], row["phase"])
     groups[key].append(row)
 
-def stats(values: list[float], prefix: str) -> dict[str, float | int]:
-    values = sorted(values)
+def stats(raw_values: list[float], prefix: str) -> dict[str, float | int]:
+    values = sorted(v for v in raw_values if not math.isnan(v))
+    if not values:
+        return {
+            "runs": 0,
+            f"avg_{prefix}": 0.0,
+            f"median_{prefix}": 0.0,
+            f"min_{prefix}": 0.0,
+            f"max_{prefix}": 0.0,
+            f"stdev_{prefix}": 0.0,
+        }
     mean = statistics.fmean(values)
     median = statistics.median(values)
     minimum = values[0]
@@ -630,24 +637,36 @@ def stats(values: list[float], prefix: str) -> dict[str, float | int]:
         f"stdev_{prefix}": stdev,
     }
 
+def safe_int(v, default=0):
+    try:
+        return int(v)
+    except (ValueError, TypeError):
+        return default
+
+def safe_float(v, default=float('nan')):
+    try:
+        return float(v)
+    except (ValueError, TypeError):
+        return default
+
 summary_rows = []
 for key in sorted(groups):
     dataset, nrows, benchmark, variant, phase = key
     records = groups[key]
     item = {
         "dataset": dataset,
-        "rows": int(nrows),
+        "rows": safe_int(nrows),
         "benchmark": benchmark,
         "variant": variant,
         "phase": phase,
-        "exit_codes": sorted({int(record["exit_code"]) for record in records}),
+        "exit_codes": sorted({safe_int(record["exit_code"], -1) for record in records}),
     }
-    item.update(stats([float(record["seconds"]) for record in records], "seconds"))
-    item.update(stats([float(record["peak_rss_kb"]) for record in records], "peak_rss_kb"))
-    item.update(stats([float(record["cpu_user_s"]) for record in records], "cpu_user_s"))
-    item.update(stats([float(record["cpu_sys_s"]) for record in records], "cpu_sys_s"))
+    item.update(stats([safe_float(record["seconds"]) for record in records], "seconds"))
+    item.update(stats([safe_float(record["peak_rss_kb"]) for record in records], "peak_rss_kb"))
+    item.update(stats([safe_float(record["cpu_user_s"]) for record in records], "cpu_user_s"))
+    item.update(stats([safe_float(record["cpu_sys_s"]) for record in records], "cpu_sys_s"))
     if "cpu_pct" in records[0]:
-        item.update(stats([float(record["cpu_pct"]) for record in records], "cpu_pct"))
+        item.update(stats([safe_float(record["cpu_pct"]) for record in records], "cpu_pct"))
     summary_rows.append(item)
 
 hot_by_benchmark = defaultdict(list)


### PR DESCRIPTION
## Summary

- **Fix `--tmp` flag format mismatch** (`barrow/cli.py`): The `--tmp` flag was forcing `input_format="feather"` even when the upstream piped command outputs CSV. This caused all `etl_pipe` and `analytics_pipe` benchmark runs (150 total) to crash. Now `--tmp` only sets the output format; input format is auto-detected from magic bytes.
- **Fix timing script crash on failures** (`scripts/benchmark.sh`): Removed `raise CalledProcessError` so metrics (including non-zero exit codes) are always recorded to results.tsv instead of producing empty fields.
- **Add defensive parsing in inline analysis** (`scripts/benchmark.sh`): Added `safe_int`/`safe_float` helpers and NaN filtering in the `stats()` function to handle any remaining edge cases with empty/invalid TSV values.
- **Guard NaN in analyze_bench.py** (`scripts/analyze_bench.py`): Protected `int(rows)` conversion against NaN values from coerced empty fields.

## Test plan

- [x] All 143 existing tests pass (`python -m pytest tests/ -v`)
- [x] `test_tmp_pipeline_feather` confirms feather-to-feather piping still works via auto-detection
- [ ] Re-run benchmark: `bash scripts/benchmark.sh --datasets tiny --only pipeline --iterations 1` to confirm `etl_pipe` and `analytics_pipe` succeed

https://claude.ai/code/session_01Gvpw6hcdKx1N8f44U6JhLE